### PR TITLE
Feature addanchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # somd2
-SOMD2 molecular dynamics for free energy calculations
+OpenBioSim - SOMD2 molecular dynamics for free energy calculations

--- a/scripts/Atoms_finding_sire_test.ipynb
+++ b/scripts/Atoms_finding_sire_test.ipynb
@@ -1,0 +1,204 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A simple jupyter notebook used to find heavy atoms within 12 and 15 angstrom of a ligand. Assumes that files 1a~1b.prm7 and 1a~1b.rst7 are in the same directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sire as sr\n",
+    "import re"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "OSError",
+     "evalue": "Cannot find file '1a~1b.prm7'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mOSError\u001b[0m                                   Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[2], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m root \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m1a~1b\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m----> 2\u001b[0m mols \u001b[39m=\u001b[39m sr\u001b[39m.\u001b[39;49mload(\u001b[39m\"\u001b[39;49m\u001b[39m%s\u001b[39;49;00m\u001b[39m.prm7\u001b[39;49m\u001b[39m\"\u001b[39;49m \u001b[39m%\u001b[39;49m root , \u001b[39m\"\u001b[39;49m\u001b[39m%s\u001b[39;49;00m\u001b[39m.rst7\u001b[39;49m\u001b[39m\"\u001b[39;49m \u001b[39m%\u001b[39;49m root)\n",
+      "File \u001b[0;32m~/mambaforge/envs/openbiosim/lib/python3.10/site-packages/sire/_load.py:399\u001b[0m, in \u001b[0;36mload\u001b[0;34m(path, show_warnings, silent, directory, gromacs_path, parallel, map, *args, **kwargs)\u001b[0m\n\u001b[1;32m    395\u001b[0m p \u001b[39m=\u001b[39m []\n\u001b[1;32m    397\u001b[0m \u001b[39mfor\u001b[39;00m i \u001b[39min\u001b[39;00m \u001b[39mrange\u001b[39m(\u001b[39m0\u001b[39m, \u001b[39mlen\u001b[39m(paths)):\n\u001b[1;32m    398\u001b[0m     \u001b[39m# resolve the paths, downloading as needed\u001b[39;00m\n\u001b[0;32m--> 399\u001b[0m     p \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m _resolve_path(paths[i], directory\u001b[39m=\u001b[39;49mdirectory, silent\u001b[39m=\u001b[39;49msilent)\n\u001b[1;32m    401\u001b[0m paths \u001b[39m=\u001b[39m p\n\u001b[1;32m    403\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mlen\u001b[39m(paths) \u001b[39m==\u001b[39m \u001b[39m0\u001b[39m:\n",
+      "File \u001b[0;32m~/mambaforge/envs/openbiosim/lib/python3.10/site-packages/sire/_load.py:261\u001b[0m, in \u001b[0;36m_resolve_path\u001b[0;34m(path, directory, silent)\u001b[0m\n\u001b[1;32m    257\u001b[0m         paths \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m _resolve_path(match, directory\u001b[39m=\u001b[39mdirectory, silent\u001b[39m=\u001b[39msilent)\n\u001b[1;32m    259\u001b[0m     \u001b[39mreturn\u001b[39;00m paths\n\u001b[0;32m--> 261\u001b[0m \u001b[39mraise\u001b[39;00m \u001b[39mIOError\u001b[39;00m(\u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mCannot find file \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mpath\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m\"\u001b[39m)\n",
+      "\u001b[0;31mOSError\u001b[0m: Cannot find file '1a~1b.prm7'"
+     ]
+    }
+   ],
+   "source": [
+    "root = \"1a~1b\"\n",
+    "mols = sr.load(\"%s.prm7\" % root , \"%s.rst7\" % root)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Change \"root\" variable according to your input file names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sr.search.set_token(\"lnd\",\"resname LIG\")\n",
+    "#sr.search.set_token(\"lnd\",\"count(atoms) > 1 and not (protein or water)\")\n",
+    "ligand = mols[\"lnd\"]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Uses a sire search token to define the criteria for the ligand, in this case the ligand is simply anything within a residue with residue name ``LIG``\n",
+    "\n",
+    "Can use some alternative search mechanism like ``sr.search.set_token(\"lnd\",\"count(atoms) > 1 and not (protein or water)\")``. This doesn't work in this case because the some parts of the truncated protein are not identified by ``protein``. A possible solution to this could be to instead search for ``not amino acid`` instead, need to check sire search functionality to see exactly how this is done."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ligand.view()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use ``view`` to check that the ligand and only the ligand is captured."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "residues = mols[\"((atoms within 15 of lnd) and (not atoms within 12 of lnd)) and protein\"]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finds all atoms between 12 and 15 angstrom from the ligand. ``atoms`` can be swapped with ``residues`` if only complete residues are required. \n",
+    "This still includes hydrogen atoms - need only heavy atoms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "residues.view()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "heavy = residues[\"not atomname /H*/\"]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Remove hydrogen atoms,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "heavy.view()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "an = heavy.numbers()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nums = []\n",
+    "for at in an:\n",
+    "    nums.append(int(re.findall(r'\\d+',str(at))[0]))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write atom numbers to a list in the form required by the addanchors script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(nums)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "sireDEV",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/scripts/addanchors.py
+++ b/scripts/addanchors.py
@@ -1,0 +1,148 @@
+import sire as sr
+import os
+import re
+import argparse
+import csv
+
+parser = argparse.ArgumentParser(
+    prog="Add Anchors",
+    description="A scipt to generate positional restraints for use in SOMD",
+)
+
+parser.add_argument(
+    "-i",
+    "--input",
+    help="Input files - should contain sire compatible coordinate and topology files.",
+    nargs=2,
+    required=True,
+)
+
+parser.add_argument(
+    "-r",
+    "--restrained",
+    help="Optional file - take in a .csv file that contains a list of restrained\
+        atoms and use those. Bypasses sire operations used to find atoms. Assumes that the file is a single line containing only the list of atom numbers",
+    type=str,
+)
+
+parser.add_argument(
+    "-d",
+    "--distances",
+    help="The distances between which to restrain atoms. Default is between 12.0 and 15.0 angstrom.",
+    nargs=2,
+    type=float,
+    default=[12.0, 15.0],
+)
+
+parser.add_argument(
+    "-o",
+    "--outname",
+    help="Name of output file. If not defined the output file will be {name of first input file}_restrained.{filetype}",
+    type=str,
+)
+
+args = parser.parse_args()
+
+mols = sr.load(args.input[0], args.input[1])
+
+if not args.restrained:
+    if args.distances[0] >= args.distances[1]:
+        raise ValueError(
+            "Restraint distances are in the wrong order, please order -d small big"
+        )
+    # Use sire to find all heavy atoms between 12 and 15 angstrom of the ligand
+    sr.search.set_token("lnd", "resname LIG")
+    ligand = mols["lnd"]
+    residues = mols[
+        "((atoms within %s of lnd) and (not atoms within %s of lnd)) and protein"
+        % (args.distances[1], args.distances[0])
+    ]
+    heavy = residues["not atomname /H*/"]
+    an = heavy.numbers()
+    restrained_atoms = []
+    for at in an:
+        restrained_atoms.append(int(re.findall(r"\d+", str(at))[0]))
+
+else:
+    with open(args.restrained) as f:
+        reader = csv.reader(f)
+        data = list(reader)
+    restrained_atoms = [int(x) for x in data[0]]
+
+print("Atomnums for restrained atoms:")
+print(restrained_atoms)
+# restrained_atoms = [18612, 18613, 18614, 18615, 18616, 18617, 18618]
+
+n_existing_atoms = mols.num_atoms()
+n_existing_residues = mols.num_residues()
+
+newmol = sr.mol.Molecule("dummies")
+
+editor = newmol.edit()
+
+# Create a residue
+editor = (
+    editor.add(sr.mol.ResName("Re"))
+    .renumber(sr.mol.ResNum(n_existing_residues + 1))
+    .molecule()
+)
+
+for i in range(0, len(restrained_atoms)):
+    editor = (
+        editor.add(sr.mol.AtomName("Re"))
+        .renumber(sr.mol.AtomNum(n_existing_atoms + i + 1))
+        .reparent(sr.mol.ResIdx(0))
+        .molecule()
+    )
+
+mol = editor.commit()
+
+cursor = mol.cursor()["atomname Re"]
+
+# need to set the properties to the correct type...
+cursor[0]["charge"] = 1 * sr.units.mod_electron
+cursor[0]["mass"] = 1 * sr.units.g_per_mol
+
+for i in range(0, len(cursor)):
+    atom = cursor.atom(i)
+    restrained_at = mols["atomnum %i" % restrained_atoms[i]]
+    atom["coordinates"] = restrained_at.property("coordinates")
+    atom["charge"] = 0 * sr.units.mod_electron
+    atom["element"] = sr.mol.Element(0)
+    atom["mass"] = 0 * sr.units.g_per_mol
+    atom["atomtype"] = "DM"
+    atom["LJ"] = sr.mm.LJParameter(1 * sr.units.angstrom, 0 * sr.units.kcal_per_mol)
+
+mol = cursor.molecule().commit()
+
+mols.add(mol)
+
+if args.outname:
+    f = sr.save(mols, args.outname, format=["PDB"])
+    f = sr.save(mols, args.outname, format=["PRM7", "RST7"])
+
+else:
+    origname = args.input[0].split(".")[0]
+    f = sr.save(mols, origname + "_restrained", format=["PDB"])
+    f = sr.save(mols, origname + "_restrained", format=["PRM7", "RST7"])
+
+# load to check
+mols = sr.load(f)
+
+# list of tuples of atoms to save, will be used to specify restraints
+# in somd-freenrg
+paired_atoms = {}
+
+last = mols[-1]
+for i in range(0, len(last.atoms())):
+    atom = last.atom(i)
+    restrained_at = mols["atomnum %i" % restrained_atoms[i]]
+    paired_atoms[atom.number().value()] = restrained_at.number().value()
+    # print(atom, atom.property("charge"), atom.property("LJ"), atom.residue())
+
+ofile = open("restraint.cfg", "w")
+ofile.write("use restraints = True\n")
+ofile.write("restrained atoms = %s\n" % paired_atoms)
+ofile.close()
+print("Atom pairs {dummy atom: original atom}:")
+print(paired_atoms)

--- a/scripts/addanchors_exampleinputs.txt
+++ b/scripts/addanchors_exampleinputs.txt
@@ -1,0 +1,4 @@
+To set up restraints with heavy atoms between 10 and 15 angstroms restrained, with input files called 1a~1b.prm7 and 1a~1b.rst7 output files named example.{ext}:
+python addanchors.py -i 1a~1b.rst7 1a~1b.prm7 -d 10 15 -o example
+To do the same, but now reading atoms from a file called "restrained.csv"
+python addanchors.py -i 1a~1b.rst7 1a~1b.prm7 -r restrained.csv -o example


### PR DESCRIPTION
Created the "scripts" folder. 
Currently contains the "addanchors.py" script which creates a modified system with dummy atoms designed to be used in cartesian restraints. It also creates a "restraint.cfg" file which can be pasted directly in to a SOMD (latest version) config file in order to create the restrained atom pairs.
Also included is a jupyter notebook that shows an example of selecting heavy atoms within a given range of a ligand using sire.