### PR TITLE
Fix issue #6

### DIFF
--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -27,10 +27,10 @@ __all__ = ["Config"]
 
 from openmm import Platform as _Platform
 from pathlib import Path as _Path
-from somd2 import _logger
 
 import sire as _sr
 
+from somd2 import _logger
 
 # List of supported Sire platforms.
 _sire_platforms = _sr.options.Platform.options()

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -20,6 +20,7 @@
 #####################################################################
 
 __all__ = ["Dynamics"]
+
 import platform as _platform
 from pathlib import Path as _Path
 
@@ -28,7 +29,6 @@ from ..io import dataframe_to_parquet as _dataframe_to_parquet
 from ..io import parquet_append as _parquet_append
 
 from somd2 import _logger
-import platform as _platform
 
 from ._runner import _lam_sym
 

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -66,7 +66,6 @@ class Runner:
 
         platform: str
             The platform to be used for simulations.
-
         """
 
         if not isinstance(system, (str, _System)):

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -22,6 +22,7 @@
 __all__ = ["Runner"]
 
 import platform as _platform
+
 from sire import stream as _stream
 from sire.system import System as _System
 
@@ -30,7 +31,6 @@ from ..io import dataframe_to_parquet as _dataframe_to_parquet
 from ..io import dict_to_yaml as _dict_to_yaml
 
 from somd2 import _logger
-import platform as _platform
 
 if _platform.system() == "Windows":
     _lam_sym = "lambda"

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -521,7 +521,7 @@ class Runner:
 
         # Early exit if no repartitioning is required.
         if isclose(factor, 1.0, abs_tol=1e-4):
-            return
+            return system
 
         from sire.morph import (
             repartition_hydrogen_masses as _repartition_hydrogen_masses,

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -112,21 +112,17 @@ class Runner:
 
         if not isclose(h_mass_factor, 1.0, abs_tol=1e-4):
             _logger.info(
-                f"Detected existing hydrogen mass repartioning factor of {h_mass_factor}."
+                f"Detected existing hydrogen mass repartioning factor of {h_mass_factor:.3f}."
             )
 
             if not isclose(h_mass_factor, self._config.h_mass_factor, abs_tol=1e-4):
+                new_factor = self._config.h_mass_factor / h_mass_factor
                 _logger.warning(
-                    f"Existing hydrogen mass repartitioning factor of {h_mass_factor} "
-                    f"does not match the requested value of {self._config.h_mass_factor}. "
-                    "Inverting exsting HMR before re-applying new factor."
+                    f"Existing hydrogen mass repartitioning factor of {h_mass_factor:.3f} "
+                    f"does not match the requested value of {self._config.h_mass_factor:.3f}. "
+                    f"Applying new factor of {new_factor:.3f}."
                 )
-                self._system = self._repartition_h_mass(
-                    self._system, factor=1.0 / h_mass_factor
-                )
-                self._system = self._repartition_h_mass(
-                    self._system, self._config.h_mass_factor
-                )
+                self._system = self._repartition_h_mass(self._system, new_factor)
 
         else:
             self._system = self._repartition_h_mass(

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -522,8 +522,10 @@ class Runner:
         if not isinstance(factor, float):
             raise TypeError("'factor' must be of type 'float'")
 
+        from math import isclose
+
         # Early exit if no repartitioning is required.
-        if factor == 1.0:
+        if isclose(factor, 1.0, abs_tol=1e-4):
             return
 
         from sire.morph import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+import sire as sr
+
+
+@pytest.fixture(scope="session")
+def ethane_methanol():
+    mols = sr.load(sr.expand(sr.tutorial_url, "merged_molecule.s3"))
+    for mol in mols.molecules("molecule property is_perturbable"):
+        mols.update(mol.perturbation().link_to_reference().commit())
+    return mols
+
+
+@pytest.fixture(scope="session")
+def ethane_methanol_hmr():
+    mols = sr.load(sr.expand(sr.tutorial_url, "merged_molecule_hmr.s3"))
+    for mol in mols.molecules("molecule property is_perturbable"):
+        mols.update(mol.perturbation().link_to_reference().commit())
+    return mols

--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -1,11 +1,12 @@
+import pytest
 import tempfile
+
 import sire as sr
+
 import somd2
+
 from somd2.config import Config
 from somd2.runner import Runner
-
-import platform
-import pytest
 
 
 def test_dynamics_options():
@@ -73,10 +74,6 @@ def test_dynamics_options():
         ) == d.integrator().__class__.__name__.lower().replace("integrator", "")
 
 
-# Skip on windows due to file permission issues
-# @pytest.mark.skipif(
-#    platform.system() == "Windows", reason="File permission issues on Windows"
-# )
 def test_logfile_creation():
     # Test that the logfile is created by either the initialisation of the runner or of a config
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/runner/test_hmr.py
+++ b/tests/runner/test_hmr.py
@@ -1,0 +1,25 @@
+import math
+
+from somd2.runner import Runner
+
+
+def test_hmr(ethane_methanol, ethane_methanol_hmr):
+    """Ensure that we can handle systems that have already been repartioned."""
+
+    hmr_factor0 = Runner._get_h_mass_factor(ethane_methanol)
+    hmr_factor1 = Runner._get_h_mass_factor(ethane_methanol_hmr)
+
+    # Make sure that the HMR factor is as expected.
+    assert math.isclose(hmr_factor0, 1.0, abs_tol=1e-4)
+    assert math.isclose(hmr_factor1, 3.0, abs_tol=1e-4)
+
+    # Invert the HMR of the second system.
+    new_system = Runner._repartition_h_mass(ethane_methanol_hmr, 1.0 / hmr_factor1)
+
+    hmr_factor2 = Runner._get_h_mass_factor(new_system)
+
+    # Make sure the HMR factor is 1.0 again.
+    assert math.isclose(hmr_factor2, 1.0, abs_tol=1e-4)
+
+
+

--- a/tests/runner/test_hmr.py
+++ b/tests/runner/test_hmr.py
@@ -15,8 +15,18 @@ def test_hmr(ethane_methanol, ethane_methanol_hmr):
 
     # Invert the HMR of the second system.
     new_system = Runner._repartition_h_mass(ethane_methanol_hmr, 1.0 / hmr_factor1)
-
     hmr_factor2 = Runner._get_h_mass_factor(new_system)
 
     # Make sure the HMR factor is 1.0 again.
     assert math.isclose(hmr_factor2, 1.0, abs_tol=1e-4)
+
+    # Work out the partial HMR factor if we actually want to use
+    # 1.5 as the HMR factor.
+    hmr_factor3 = 1.5 / hmr_factor1
+
+    # Now apply the partial HMR factor.
+    new_system = Runner._repartition_h_mass(ethane_methanol_hmr, hmr_factor3)
+    hmr_factor4 = Runner._get_h_mass_factor(new_system)
+
+    # Make sure the HMR factor is 1.5.
+    assert math.isclose(hmr_factor4, 1.5, abs_tol=1e-4)

--- a/tests/runner/test_hmr.py
+++ b/tests/runner/test_hmr.py
@@ -20,6 +20,3 @@ def test_hmr(ethane_methanol, ethane_methanol_hmr):
 
     # Make sure the HMR factor is 1.0 again.
     assert math.isclose(hmr_factor2, 1.0, abs_tol=1e-4)
-
-
-

--- a/tests/runner/test_restart.py
+++ b/tests/runner/test_restart.py
@@ -10,13 +10,14 @@ from somd2.config import Config
 from somd2.io import *
 
 
-def test_restart():
-    """Validate that a simulation can be run from a checkpoint file,
+@pytest.mark.parametrize("mols", ["ethane_methanol", "ethane_methanol_hmr"])
+def test_restart(mols, request):
+    """
+    Validate that a simulation can be run from a checkpoint file,
     with all trajcetories preserved.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Load the demo stream file.
-        mols = sr.load(sr.expand(sr.tutorial_url, "merged_molecule.s3"))
+        mols = request.getfixturevalue(mols)
 
         config = {
             "runtime": "12fs",
@@ -210,7 +211,3 @@ def test_restart():
         # Load the new checkpoint file and make sure the restart fails
         with pytest.raises(ValueError):
             runner_badconfig = Runner(mols, Config(**config_new))
-
-
-if __name__ == "__main__":
-    test_restart()

--- a/tests/runner/test_restart.py
+++ b/tests/runner/test_restart.py
@@ -1,10 +1,13 @@
+from pathlib import Path
+
 import tempfile
+import pytest
+
+import sire as sr
+
 from somd2.runner import Runner
 from somd2.config import Config
 from somd2.io import *
-from pathlib import Path
-import sire as sr
-import pytest
 
 
 def test_restart():


### PR DESCRIPTION
This PR closes #6 by allowing `somd2` to be able to simulate systems where HMR has already been applied. This is done by detecting the existing `h_mass_factor` and applying a new factor of `Config.h_mass_factor /  h_mass_factor`. No repartitioning is performed if the existing factor matches the one specified by the config.

I've added a test to make sure that the HMR factor is detected correctly and that the value is correctly updated following rescaling. I've also parameterised the restart test over two perturbable systems, one with HMR and one without, allowing us to confirm that the runner does work if HMR is already present.

Due to the limited precision of atomic masses in text based input files I've added some rounding when comparing hydrogen masses to ensure that we don't unnecessarily perform HMR when the hydrogen mass is sufficiently close to the desired value. 