### PR TITLE
[WIP] Fix 9

### DIFF
--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -100,7 +100,7 @@ class Config:
         output_directory="output",
         restart=False,
         write_config=True,
-        supress_overwrite_warning=False,
+        overwrite=False,
     ):
         """
         Constructor.
@@ -209,8 +209,10 @@ class Config:
         log_file: str
             Name of log file, will be saved in output directory.
 
-        supress_overwrite_warning: bool
-            Whether to supress the warning when overwriting files in the output directory.
+        overwrite: bool
+            Whether to overwrite files in the output directory.
+            If not False and files already exist, somd2 will exit before anything
+            is deleted or overwritten.
         """
 
         # Setup logger before doing anything else
@@ -249,7 +251,7 @@ class Config:
 
         self.write_config = write_config
 
-        self.supress_overwrite_warning = supress_overwrite_warning
+        self.overwrite = overwrite
 
     def __str__(self):
         """Return a string representation of this object."""
@@ -972,14 +974,14 @@ class Config:
         self._log_file = log_file
 
     @property
-    def supress_overwrite_warning(self):
-        return self._supress_overwrite_warning
+    def overwrite(self):
+        return self._overwrite
 
-    @supress_overwrite_warning.setter
-    def supress_overwrite_warning(self, supress_overwrite_warning):
-        if not isinstance(supress_overwrite_warning, bool):
-            raise ValueError("'supress_overwrite_warning' must be of type 'bool'")
-        self._supress_overwrite_warning = supress_overwrite_warning
+    @overwrite.setter
+    def overwrite(self, overwrite):
+        if not isinstance(overwrite, bool):
+            raise ValueError("'overwrite' must be of type 'bool'")
+        self._overwrite = overwrite
 
     @classmethod
     def _create_parser(cls):

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -899,6 +899,11 @@ class Config:
     def restart(self, restart):
         if not isinstance(restart, bool):
             raise ValueError("'restart' must be of type 'bool'")
+        if restart and (self.equilibration_time > 0.0):
+            _logger.warning(
+                f"Restarting from a previous simulation"
+                f"- equilibration will be skipped for systems starting from checkpoint files."
+            )
         self._restart = restart
 
     @property

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -245,7 +245,7 @@ class Dynamics:
         # Run minimisation at the end of equilibration as the timestep may be changing
         self._minimisation()
 
-    def _run(self, lambda_minimisation=None):
+    def _run(self, lambda_minimisation=None, is_restart=False):
         """
         Run the simulation with bookkeeping.
 
@@ -273,7 +273,7 @@ class Dynamics:
         if self._config.minimise:
             self._minimisation(lambda_minimisation)
 
-        if self._config.equilibration_time.value() > 0.0:
+        if (self._config.equilibration_time.value() > 0.0) and not is_restart:
             self._equilibration()
             # Reset the timer to zero
             self._system.set_time(_u("0ps"))

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -313,8 +313,8 @@ class Dynamics:
 
         # First need to link coordinates and coordinates0
         for mol_noHMR, mol_HMR in zip(
-            self._system_noHMR.molecules("molecule has property is_perturbable"),
-            self._system.molecules("molecule has property is_perturbable"),
+            self._system_noHMR.molecules("molecule property is_perturbable"),
+            self._system.molecules("molecule property is_perturbable"),
         ):
             mol1 = mol_noHMR.edit().add_link("coordinates", "coordinates0")
             self._system_noHMR.update(mol1)
@@ -324,7 +324,7 @@ class Dynamics:
         # Now copy coordinates and velocities (uses old sire API, hence system._system)
         from sire.legacy.IO import updateCoordinatesAndVelocities
 
-        self._system._system = updateCoordinatesAndVelocities(
+        self._system._system, _ = updateCoordinatesAndVelocities(
             self._system._system,
             self._system._system,
             self._system_noHMR._system,

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -180,8 +180,8 @@ class Dynamics:
                 schedule=self._config.lambda_schedule,
                 platform=self._config.platform,
                 device=self._device,
-                constraint=None,
-                perturbable_constraint=None,
+                constraint="none",
+                perturbable_constraint="none",
                 vacuum=not self._has_space,
                 map=map,
             )

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -174,8 +174,8 @@ class Dynamics:
             schedule=self._config.lambda_schedule,
             platform=self._config.platform,
             device=self._device,
-            constraint="none" if equilibration else self._config.constraint,
-            perturbable_constraint="none"
+            constraint=None if equilibration else self._config.constraint,
+            perturbable_constraint=None
             if equilibration
             else self._config.perturbable_constraint,
             vacuum=not self._has_space,

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -210,13 +210,21 @@ class Runner:
                     if __Path.exists(fullpath):
                         deleted.append(fullpath)
         if len(deleted) > 0:
-            if not self._config.supress_overwrite_warning:
+            import sys
+
+            if not self._config.overwrite:
                 deleted_str = [str(file) for file in deleted]
                 _logger.warning(
                     f"The following files already exist and will be overwritten: {list(set((deleted_str)))} \n"
                 )
-                _logger.warning("Press Enter to continue or Ctrl-C to cancel...")
-                input()
+                _logger.warning(
+                    """
+                        ############################################################################
+                        ##EXITING. Set overwrite to True in order to overwrite pre-existing files.##
+                        ############################################################################
+                    """
+                )
+                sys.exit()
             # Loop over files to be deleted, ignoring duplicates
             for file in list(set(deleted)):
                 file.unlink()
@@ -251,7 +259,7 @@ class Runner:
             "write_config",
             "log_level",
             "log_file",
-            "supress_overwrite_warning",
+            "overwrite",
         ]
         for key in config1.keys():
             if key not in allowed_diffs:

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -129,6 +129,10 @@ class Runner:
                 self._system, self._config.h_mass_factor
             )
 
+        # Link properties to the lambda = 0 end state for the HMR system.
+        for mol in self._system_HMR.molecules("molecule property is_perturbable"):
+            self._system_HMR.update(mol.perturbation().link_to_reference().commit())
+
         # Flag whether this is a GPU simulation.
         self._is_gpu = self._config.platform in ["cuda", "opencl", "hip"]
 

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -112,7 +112,7 @@ class Runner:
 
         if not isclose(h_mass_factor, 1.0, abs_tol=1e-4):
             _logger.info(
-                f"Detected existing hydrogen mass repartioning factor of {h_mass_factor:.3f}."
+                f"Detected existing hydrogen mass repartioning factor of {h_mass_factor:.3f} in the base system."
             )
 
             if not isclose(h_mass_factor, self._config.h_mass_factor, abs_tol=1e-4):
@@ -120,14 +120,14 @@ class Runner:
                 _logger.warning(
                     f"Existing hydrogen mass repartitioning factor of {h_mass_factor:.3f} "
                     f"does not match the requested value of {self._config.h_mass_factor:.3f}. "
-                    f"Applying new factor of {new_factor:.3f}."
+                    f"A new factor of {new_factor:.3f} will be applied."
                 )
-                self._system = self._repartition_h_mass(self._system, new_factor)
+                # self._system = self._repartition_h_mass(self._system, new_factor)
 
-        else:
-            self._system = self._repartition_h_mass(
-                self._system, self._config.h_mass_factor
-            )
+        # else:
+        #    self._system = self._repartition_h_mass(
+        #        self._system, self._config.h_mass_factor
+        #    )
 
         # Flag whether this is a GPU simulation.
         self._is_gpu = self._config.platform in ["cuda", "opencl", "hip"]

--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -19,8 +19,10 @@ def test_dynamics_options():
         # (All default options, other than platform="cpu".)
         runner = Runner(mols, Config(platform="cpu", output_directory=tmpdir))
 
-        # Initalise a fake simulation.
-        runner._initialise_simulation(runner._system.clone(), 0.0)
+        # Initalise a fake simulation. Give another copy of the system as the noHMR version
+        runner._initialise_simulation(
+            runner._system.clone(), 0.0, system_noHMR=runner._system.clone()
+        )
 
         # Setup a dynamics object for equilibration.
         runner._sim._setup_dynamics(equilibration=True)

--- a/tests/runner/test_restart.py
+++ b/tests/runner/test_restart.py
@@ -56,7 +56,7 @@ def test_restart(mols, request):
             "platform": "CPU",
             "max_threads": 1,
             "num_lambda": 2,
-            "supress_overwrite_warning": True,
+            "overwrite": True,
             "log_level": "DEBUG",
         }
 


### PR DESCRIPTION
Fix for issue #9 . Changes the following:
- Refactor for HMR means that it is now performed in `_dynamics.py`, specifically _after_ equilibration (if applicable).
- Adds additional minimisation between equilibration and production.
- If `restart==True` and equilibration is requested, somd2 will now only equilibrate the systems that are starting from scratch, all systems restarting from file will be subject only to minimisation.
- Somd2 will now exit upon instances of file overwriting, rather than requesting user input, this can be bypassed by the new `overwrite` option (which replaces the `supress_overwrite_warning` option). Also made the logger warninig for this particular interaction more obvious.