### PR TITLE
Changed default behaviour of perturbable_constraints - now defaults to None rather than none

### DIFF
--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -153,7 +153,9 @@ class Config:
             Constraint type to use for non-perturbable molecules.
 
         perturbable_constraint: str
-            Constraint type to use for perturbable molecules.
+            Constraint type to use for perturbable molecules. If None, then
+            this will be set according to what is chosen for the
+            non-perturbable constraint.
 
         minimise: bool
             Whether to minimise the system before simulation.


### PR DESCRIPTION
Quick patch for the issue mentioned in #13 , this behaviour will need to be updated again in the near future, but this should increase stability for now. 