### PR TITLE
Make sure docstring lines are joined with a space

### DIFF
--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -200,7 +200,7 @@ class Config:
             Path to a directory to store output files.
 
         restart: bool
-            Whether to restart from a previous simulation - files found in `output-directory`.
+            Whether to restart from a previous simulation using files found in 'output-directory'.
 
         write_config: bool
             Whether to write the configuration options to a YAML file in the output directory.
@@ -1013,7 +1013,7 @@ class Config:
                         found_param = False
                         break
                     else:
-                        string += line
+                        string += f" {line}"
 
             # Store the help string for this parameter.
             help[param] = string


### PR DESCRIPTION
This PR fixes the formatting of the help message printed by the CLI by joining the docstring lines for `Config` parameters with a space character. Previously, the lines were just appended so there was no space between.

_Before_:

```
  --perturbable-constraint {none,auto,h_bonds,bonds,h_bonds_h_angles,bonds_h_angles}
                        Constraint type to use for perturbable molecules. If None, thenthis will be set according to what is chosen for
                        thenon-perturbable constraint. (default: None)
```

_After_:

```
  --perturbable-constraint {none,auto,h_bonds,bonds,h_bonds_h_angles,bonds_h_angles}
                        Constraint type to use for perturbable molecules. If None, then this will be set according to what is chosen for
                        the non-perturbable constraint. (default: None)
```
