### PR TITLE
Fix 9

### DIFF
--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -100,7 +100,7 @@ class Config:
         output_directory="output",
         restart=False,
         write_config=True,
-        supress_overwrite_warning=False,
+        overwrite=False,
     ):
         """
         Constructor.
@@ -211,8 +211,9 @@ class Config:
         log_file: str
             Name of log file, will be saved in output directory.
 
-        supress_overwrite_warning: bool
-            Whether to supress the warning when overwriting files in the output directory.
+        overwrite: bool
+            Whether to overwrite files in the output directory, if files are detected and
+            this is false, SOMD2 will exit without overwriting.
         """
 
         # Setup logger before doing anything else
@@ -251,7 +252,7 @@ class Config:
 
         self.write_config = write_config
 
-        self.supress_overwrite_warning = supress_overwrite_warning
+        self.overwrite = overwrite
 
     def __str__(self):
         """Return a string representation of this object."""
@@ -965,14 +966,14 @@ class Config:
         self._log_file = log_file
 
     @property
-    def supress_overwrite_warning(self):
-        return self._supress_overwrite_warning
+    def overwrite(self):
+        return self._overwrite
 
-    @supress_overwrite_warning.setter
-    def supress_overwrite_warning(self, supress_overwrite_warning):
-        if not isinstance(supress_overwrite_warning, bool):
-            raise ValueError("'supress_overwrite_warning' must be of type 'bool'")
-        self._supress_overwrite_warning = supress_overwrite_warning
+    @overwrite.setter
+    def overwrite(self, overwrite):
+        if not isinstance(overwrite, bool):
+            raise ValueError("'overwrite' must be of type 'bool'")
+        self._overwrite = overwrite
 
     @classmethod
     def _create_parser(cls):

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -161,7 +161,8 @@ class Config:
             Whether to minimise the system before simulation.
 
         equilibration_time: str
-            Time interval for equilibration.
+            Time interval for equilibration. Only simulations starting from
+            scratch will be equilibrated.
 
         equilibration_timestep: str
             Equilibration timestep. (Can be different to simulation timestep.)

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -252,7 +252,7 @@ class Dynamics:
                 perturbable_constraint=self._config.perturbable_constraint,
             )
 
-    def _run(self, lambda_minimisation=None):
+    def _run(self, lambda_minimisation=None, is_restart=False):
         """
         Run the simulation with bookkeeping.
 
@@ -280,7 +280,7 @@ class Dynamics:
         if self._config.minimise:
             self._minimisation(lambda_minimisation)
 
-        if self._config.equilibration_time.value() > 0.0:
+        if self._config.equilibration_time.value() > 0.0 and not is_restart:
             self._equilibration()
             # Reset the timer to zero
             self._system.set_time(_u("0ps"))

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -182,7 +182,7 @@ class Dynamics:
             map=map,
         )
 
-    def _minimisation(self, lambda_min=None):
+    def _minimisation(self, lambda_min=None, perturbable_constraint="none"):
         """
         Minimisation of self._system.
 
@@ -202,6 +202,7 @@ class Dynamics:
                     lambda_value=self._lambda_val,
                     platform=self._config.platform,
                     vacuum=not self._has_space,
+                    perturbable_constraint=perturbable_constraint,
                     map=self._config._extra_args,
                 )
                 m.run()
@@ -217,6 +218,7 @@ class Dynamics:
                     lambda_value=lambda_min,
                     platform=self._config.platform,
                     vacuum=not self._has_space,
+                    perturbable_constraint=perturbable_constraint,
                     map=self._config._extra_args,
                 )
                 m.run()
@@ -242,6 +244,13 @@ class Dynamics:
             auto_fix_minimise=False,
         )
         self._system = self._dyn.commit()
+        # Perform brief minimisation at the end of equilibration only if the
+        # timestep is increasing
+        if self._config.timestep > self._config.equilibration_timestep:
+            self._minimisation(
+                lambda_min=self._lambda_val,
+                perturbable_constraint=self._config.perturbable_constraint,
+            )
 
     def _run(self, lambda_minimisation=None):
         """

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -216,13 +216,12 @@ class Runner:
                     if __Path.exists(fullpath):
                         deleted.append(fullpath)
         if len(deleted) > 0:
-            if not self._config.supress_overwrite_warning:
+            if not self._config.overwrite:
                 deleted_str = [str(file) for file in deleted]
                 _logger.warning(
-                    f"The following files already exist and will be overwritten: {list(set((deleted_str)))} \n"
+                    f"The following files already exist, use --overwrite to overwrite them: {list(set((deleted_str)))} \n"
                 )
-                _logger.warning("Press Enter to continue or Ctrl-C to cancel...")
-                input()
+                exit(1)
             # Loop over files to be deleted, ignoring duplicates
             for file in list(set(deleted)):
                 file.unlink()
@@ -257,7 +256,7 @@ class Runner:
             "write_config",
             "log_level",
             "log_file",
-            "supress_overwrite_warning",
+            "overwrite",
         ]
         for key in config1.keys():
             if key not in allowed_diffs:

--- a/tests/runner/test_restart.py
+++ b/tests/runner/test_restart.py
@@ -56,7 +56,7 @@ def test_restart(mols, request):
             "platform": "CPU",
             "max_threads": 1,
             "num_lambda": 2,
-            "supress_overwrite_warning": True,
+            "overwrite": True,
             "log_level": "DEBUG",
         }
 


### PR DESCRIPTION
Three changes:
1) Updates to the equilibration methodology to include a post-equilibration minimisation.
2) Equilibration now skips simulations that are restarting from checkpoint 
3) Changes the --supress-overwrite-warning flag to --overwrite, with the behaviour changing from requiring the enter key to be pressed, to the code exiting if files are detected and overwrite is False.