### PR TITLE
Expose cutoff kwarg

### DIFF
--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -453,7 +453,7 @@ class Config:
     def cutoff(self):
         return self._cutoff
 
-    @cutoff_type.setter
+    @cutoff.setter
     def cutoff(self, cutoff):
         if not isinstance(cutoff, str):
             raise TypeError("'cutoff' must be of type 'str'")

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -442,7 +442,7 @@ class Config:
     def cutoff_type(self, cutoff_type):
         if not isinstance(cutoff_type, str):
             raise TypeError("'cutoff_type' must be of type 'str'")
-        cutoff = cutoff_type.lower().replace(" ", "")
+        cutoff_type = cutoff_type.lower().replace(" ", "")
         if cutoff_type not in self._choices["cutoff_type"]:
             raise ValueError(
                 f"Cutoff type not recognised. Valid cutoff types are: {', '.join(self._choices['cutoff_type'])}"

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -76,6 +76,7 @@ class Config:
         pressure="1 atm",
         integrator="langevin_middle",
         cutoff_type="pme",
+        cutoff="7.5A",
         h_mass_factor=1.5,
         num_lambda=11,
         lambda_schedule="standard_morph",
@@ -125,6 +126,9 @@ class Config:
 
         cutoff_type: str
             Cutoff type to use for simulation.
+
+        cutoff: str
+            Non-bonded cutoff distance.
 
         h_mass_factor: float
             Factor by which to scale hydrogen masses.
@@ -227,6 +231,7 @@ class Config:
         self.pressure = pressure
         self.integrator = integrator
         self.cutoff_type = cutoff_type
+        self.cutoff = cutoff
         self.h_mass_factor = h_mass_factor
         self.timestep = timestep
         self.num_lambda = num_lambda
@@ -443,6 +448,32 @@ class Config:
                 f"Cutoff type not recognised. Valid cutoff types are: {', '.join(self._choices['cutoff_type'])}"
             )
         self._cutoff_type = cutoff_type
+
+    @property
+    def cutoff(self):
+        return self._cutoff
+
+    @cutoff_type.setter
+    def cutoff(self, cutoff):
+        if not isinstance(cutoff, str):
+            raise TypeError("'cutoff' must be of type 'str'")
+
+        from sire.units import angstrom
+
+        if cutoff is not None:
+            try:
+                c = _sr.u(cutoff)
+            except:
+                raise ValueError(
+                    f"Unable to parse 'cutoff' as a Sire GeneralUnit: {cutoff}"
+                )
+            if not c.has_same_units(angstrom):
+                raise ValueError("'cutoff' units are invalid.")
+
+            self._cutoff = c
+
+        else:
+            self._cutoff = cutoff
 
     @property
     def h_mass_factor(self):

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -461,16 +461,20 @@ class Config:
         from sire.units import angstrom
 
         if cutoff is not None:
-            try:
-                c = _sr.u(cutoff)
-            except:
-                raise ValueError(
-                    f"Unable to parse 'cutoff' as a Sire GeneralUnit: {cutoff}"
-                )
-            if not c.has_same_units(angstrom):
-                raise ValueError("'cutoff' units are invalid.")
+            # Handle special case of cutoff = "infinite"
+            if cutoff.lower().replace(" ", "") == "infinite":
+                self._cutoff = "infinite"
+            else:
+                try:
+                    c = _sr.u(cutoff)
+                except:
+                    raise ValueError(
+                        f"Unable to parse 'cutoff' as a Sire GeneralUnit: {cutoff}"
+                    )
+                if not c.has_same_units(angstrom):
+                    raise ValueError("'cutoff' units are invalid.")
 
-            self._cutoff = c
+                self._cutoff = c
 
         else:
             self._cutoff = cutoff

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -171,6 +171,7 @@ class Dynamics:
             else self._config.timestep,
             lambda_value=self._lambda_val,
             cutoff_type=self._config.cutoff_type,
+            cutoff=self._config.cutoff,
             schedule=self._config.lambda_schedule,
             platform=self._config.platform,
             device=self._device,
@@ -198,6 +199,7 @@ class Dynamics:
             try:
                 m = self._system.minimisation(
                     cutoff_type=self._config.cutoff_type,
+                    cutoff=self._config.cutoff,
                     schedule=self._config.lambda_schedule,
                     lambda_value=self._lambda_val,
                     platform=self._config.platform,
@@ -214,6 +216,7 @@ class Dynamics:
             try:
                 m = self._system.minimisation(
                     cutoff_type=self._config.cutoff_type,
+                    cutoff=self._config.cutoff,
                     schedule=self._config.lambda_schedule,
                     lambda_value=lambda_min,
                     platform=self._config.platform,


### PR DESCRIPTION
This PR exposes the `cutoff` kwarg used in `sire` minimisation and dynamics. (Previously we only exposed the `cutoff_type` and let `sire` choose the default `cutoff`.) This option is exposed as a string, which is (generally) parsed as a length based general unit. I've added support for the special case of `cutoff="infinite"`, which can't be parsed in the same way. At present we don't automatically adjust the `cutoff` for vacuum simulations. If this is something that we want to do, then it can be combined with the space check that enforces `cutoff_type="rf` for vacuum simulations, e.g. we could set `cutoff="infinite"` here if needed.