### PR TITLE
Add SOMD1 compatibility mode

### DIFF
--- a/src/somd2/__init__.py
+++ b/src/somd2/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # SOMD2: GPU accelerated alchemical free-energy engine.
 #
-# Copyright: 2023
+# Copyright: 2023-2024
 #
 # Authors: The OpenBioSim Team <team@openbiosim.org>
 #

--- a/src/somd2/app/__init__.py
+++ b/src/somd2/app/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # SOMD2: GPU accelerated alchemical free-energy engine.
 #
-# Copyright: 2023
+# Copyright: 2023-2024
 #
 # Authors: The OpenBioSim Team <team@openbiosim.org>
 #

--- a/src/somd2/app/run.py
+++ b/src/somd2/app/run.py
@@ -37,10 +37,18 @@ def cli():
 
     from argparse import Namespace
 
+    from somd2 import _logger
     from somd2.config import Config
     from somd2.runner import Runner
 
     from somd2.io import yaml_to_dict
+
+    # Store the somd2 version.
+    from somd2._version import __version__
+
+    # Store the sire version.
+    from sire import __version__ as sire_version
+    from sire import __revisionid__ as sire_revisionid
 
     # Generate the parser.
     parser = Config._create_parser()
@@ -75,6 +83,10 @@ def cli():
 
     # Instantiate a Config object to validate the arguments.
     config = Config(**args)
+
+    # Log the versions of somd2 and sire.
+    _logger.info(f"somd2 version: {__version__}")
+    _logger.info(f"sire version: {sire_version}+{sire_revisionid}")
 
     # Instantiate a Runner object to run the simulation.
     runner = Runner(system, config)

--- a/src/somd2/app/run.py
+++ b/src/somd2/app/run.py
@@ -1,7 +1,7 @@
 ######################################################################
 # SOMD2: GPU accelerated alchemical free-energy engine.
 #
-# Copyright: 2023
+# Copyright: 2023-2024
 #
 # Authors: The OpenBioSim Team <team@openbiosim.org>
 #

--- a/src/somd2/config/__init__.py
+++ b/src/somd2/config/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # SOMD2: GPU accelerated alchemical free-energy engine.
 #
-# Copyright: 2023
+# Copyright: 2023-2024
 #
 # Authors: The OpenBioSim Team <team@openbiosim.org>
 #

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -85,7 +85,8 @@ class Config:
         coulomb_power=0.0,
         shift_delta="2A",
         constraint="h_bonds",
-        perturbable_constraint=None,
+        perturbable_constraint="h_bonds_not_perturbed",
+        include_constrained_energies=False,
         minimise=True,
         equilibration_time="0ps",
         equilibration_timestep="1fs",
@@ -160,6 +161,9 @@ class Config:
             Constraint type to use for perturbable molecules. If None, then
             this will be set according to what is chosen for the
             non-perturbable constraint.
+
+        include_constrained_energies: bool
+            Whether to include constrained energies in the potential.
 
         minimise: bool
             Whether to minimise the system before simulation.
@@ -242,6 +246,7 @@ class Config:
         self.shift_delta = shift_delta
         self.constraint = constraint
         self.perturbable_constraint = perturbable_constraint
+        self.include_constrained_energies = include_constrained_energies
         self.minimise = minimise
         self.equilibration_time = equilibration_time
         self.equilibration_timestep = equilibration_timestep
@@ -656,6 +661,16 @@ class Config:
                 self._perturbable_constraint = perturbable_constraint
         else:
             self._perturbable_constraint = None
+
+    @property
+    def include_constrained_energies(self):
+        return self._include_constrained_energies
+
+    @include_constrained_energies.setter
+    def include_constrained_energies(self, include_constrained_energies):
+        if not isinstance(include_constrained_energies, bool):
+            raise ValueError("'include_constrained_energies' must be of type 'bool'")
+        self._include_constrained_energies = include_constrained_energies
 
     @property
     def minimise(self):

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -87,6 +87,7 @@ class Config:
         constraint="h_bonds",
         perturbable_constraint="h_bonds_not_perturbed",
         include_constrained_energies=False,
+        dynamic_constraints=True,
         com_reset_frequency=10,
         minimise=True,
         equilibration_time="0ps",
@@ -165,6 +166,13 @@ class Config:
 
         include_constrained_energies: bool
             Whether to include constrained energies in the potential.
+
+        dynamic_constraints: bool
+            Whether or not to update the length of constraints of perturbable
+            bonds with lambda. This defaults to True, meaning that changing
+            lambda will change any constraint on a perturbable bond to equal
+            to the value of r0 at that lambda value. If this is False, then
+            the constraint is set based on the current length.
 
         com_reset_frequency: int
             Frequency at which to reset the centre of mass of the system.
@@ -251,6 +259,7 @@ class Config:
         self.constraint = constraint
         self.perturbable_constraint = perturbable_constraint
         self.include_constrained_energies = include_constrained_energies
+        self.dynamic_constraints = dynamic_constraints
         self.com_reset_frequency = com_reset_frequency
         self.minimise = minimise
         self.equilibration_time = equilibration_time
@@ -676,6 +685,16 @@ class Config:
         if not isinstance(include_constrained_energies, bool):
             raise ValueError("'include_constrained_energies' must be of type 'bool'")
         self._include_constrained_energies = include_constrained_energies
+
+    @property
+    def dynamic_constraints(self):
+        return self._dynamic_constraints
+
+    @dynamic_constraints.setter
+    def dynamic_constraints(self, dynamic_constraints):
+        if not isinstance(dynamic_constraints, bool):
+            raise ValueError("'dynamic_constraints' must be of type 'bool'")
+        self._dynamic_constraints = dynamic_constraints
 
     @property
     def com_reset_frequency(self):

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -1,7 +1,7 @@
 ######################################################################
 # SOMD2: GPU accelerated alchemical free-energy engine.
 #
-# Copyright: 2023
+# Copyright: 2023-2024
 #
 # Authors: The OpenBioSim Team <team@openbiosim.org>
 #

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -105,6 +105,7 @@ class Config:
         restart=False,
         write_config=True,
         overwrite=False,
+        somd1_compatibility=False,
     ):
         """
         Constructor.
@@ -235,6 +236,9 @@ class Config:
         overwrite: bool
             Whether to overwrite files in the output directory, if files are detected and
             this is false, SOMD2 will exit without overwriting.
+
+        somd1_compatibility: bool
+            Whether to run using a SOMD1 compatible perturbation.
         """
 
         # Setup logger before doing anything else
@@ -274,6 +278,7 @@ class Config:
         self.max_gpus = max_gpus
         self.run_parallel = run_parallel
         self.restart = restart
+        self.somd1_compatibility = somd1_compatibility
 
         self.write_config = write_config
 
@@ -987,6 +992,16 @@ class Config:
         if not isinstance(restart, bool):
             raise ValueError("'restart' must be of type 'bool'")
         self._restart = restart
+
+    @property
+    def somd1_compatibility(self):
+        return self._somd1_compatibility
+
+    @somd1_compatibility.setter
+    def somd1_compatibility(self, somd1_compatibility):
+        if not isinstance(somd1_compatibility, bool):
+            raise ValueError("'somd1_compatibility' must be of type 'bool'")
+        self._somd1_compatibility = somd1_compatibility
 
     @property
     def output_directory(self):

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -87,6 +87,7 @@ class Config:
         constraint="h_bonds",
         perturbable_constraint="h_bonds_not_perturbed",
         include_constrained_energies=False,
+        com_reset_frequency=10,
         minimise=True,
         equilibration_time="0ps",
         equilibration_timestep="1fs",
@@ -164,6 +165,9 @@ class Config:
 
         include_constrained_energies: bool
             Whether to include constrained energies in the potential.
+
+        com_reset_frequency: int
+            Frequency at which to reset the centre of mass of the system.
 
         minimise: bool
             Whether to minimise the system before simulation.
@@ -247,6 +251,7 @@ class Config:
         self.constraint = constraint
         self.perturbable_constraint = perturbable_constraint
         self.include_constrained_energies = include_constrained_energies
+        self.com_reset_frequency = com_reset_frequency
         self.minimise = minimise
         self.equilibration_time = equilibration_time
         self.equilibration_timestep = equilibration_timestep
@@ -671,6 +676,19 @@ class Config:
         if not isinstance(include_constrained_energies, bool):
             raise ValueError("'include_constrained_energies' must be of type 'bool'")
         self._include_constrained_energies = include_constrained_energies
+
+    @property
+    def com_reset_frequency(self):
+        return self._com_reset_frequency
+
+    @com_reset_frequency.setter
+    def com_reset_frequency(self, com_reset_frequency):
+        if not isinstance(com_reset_frequency, int):
+            try:
+                com_reset_frequency = int(com_reset_frequency)
+            except Exception:
+                raise ValueError("'com_reset_frequency' must of type 'int'")
+        self._com_reset_frequency = com_reset_frequency
 
     @property
     def minimise(self):

--- a/src/somd2/io/__init__.py
+++ b/src/somd2/io/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # SOMD2: GPU accelerated alchemical free-energy engine.
 #
-# Copyright: 2023
+# Copyright: 2023-2024
 #
 # Authors: The OpenBioSim Team <team@openbiosim.org>
 #

--- a/src/somd2/io/_io.py
+++ b/src/somd2/io/_io.py
@@ -1,7 +1,7 @@
 ######################################################################
 # SOMD2: GPU accelerated alchemical free-energy engine.
 #
-# Copyright: 2023
+# Copyright: 2023-2024
 #
 # Authors: The OpenBioSim Team <team@openbiosim.org>
 #

--- a/src/somd2/runner/__init__.py
+++ b/src/somd2/runner/__init__.py
@@ -1,7 +1,7 @@
 ######################################################################
 # SOMD2: GPU accelerated alchemical free-energy engine.
 #
-# Copyright: 2023
+# Copyright: 2023-2024
 #
 # Authors: The OpenBioSim Team <team@openbiosim.org>
 #

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -179,6 +179,7 @@ class Dynamics:
             perturbable_constraint="none"
             if equilibration
             else self._config.perturbable_constraint,
+            include_constrained_energies=self._config.include_constrained_energies,
             vacuum=not self._has_space,
             map=map,
         )
@@ -205,6 +206,7 @@ class Dynamics:
                     platform=self._config.platform,
                     vacuum=not self._has_space,
                     perturbable_constraint=perturbable_constraint,
+                    include_constrained_energies=self._config.include_constrained_energies,
                     map=self._config._extra_args,
                 )
                 m.run()
@@ -222,6 +224,7 @@ class Dynamics:
                     platform=self._config.platform,
                     vacuum=not self._has_space,
                     perturbable_constraint=perturbable_constraint,
+                    include_constrained_energies=self._config.include_constrained_energies,
                     map=self._config._extra_args,
                 )
                 m.run()

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -180,7 +180,9 @@ class Dynamics:
             if equilibration
             else self._config.perturbable_constraint,
             include_constrained_energies=self._config.include_constrained_energies,
+            dynamic_constraints=self._config.dynamic_constraints,
             swap_end_states=self._config.swap_end_states,
+            com_reset_frequency=self._config.com_reset_frequency,
             vacuum=not self._has_space,
             map=map,
         )
@@ -208,6 +210,7 @@ class Dynamics:
                     vacuum=not self._has_space,
                     perturbable_constraint=perturbable_constraint,
                     include_constrained_energies=self._config.include_constrained_energies,
+                    dynamic_constraints=self._config.dynamic_constraints,
                     swap_end_states=self._config.swap_end_states,
                     map=self._config._extra_args,
                 )
@@ -227,6 +230,7 @@ class Dynamics:
                     vacuum=not self._has_space,
                     perturbable_constraint=perturbable_constraint,
                     include_constrained_energies=self._config.include_constrained_energies,
+                    dynamic_constraints=self._config.dynamic_constraints,
                     swap_end_states=self._config.swap_end_states,
                     map=self._config._extra_args,
                 )

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -342,7 +342,9 @@ class Dynamics:
                 try:
                     self._system = self._dyn.commit()
                     _stream.save(self._system, str(sire_checkpoint_name))
-                    df = self._system.energy_trajectory(to_alchemlyb=True)
+                    df = self._system.energy_trajectory(
+                        to_alchemlyb=True, energy_unit="kT"
+                    )
                     if x == 0:
                         # Not including speed in checkpoints for now.
                         f = _dataframe_to_parquet(
@@ -411,7 +413,7 @@ class Dynamics:
             _save(self._system.trajectory(), traj_filename, format=["DCD"])
         # dump final system to checkpoint file
         _stream.save(self._system, sire_checkpoint_name)
-        df = self._system.energy_trajectory(to_alchemlyb=True)
+        df = self._system.energy_trajectory(to_alchemlyb=True, energy_unit="kT")
         return df
 
     def get_timing(self):

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -1,7 +1,7 @@
 ######################################################################
 # SOMD2: GPU accelerated alchemical free-energy engine.
 #
-# Copyright: 2023
+# Copyright: 2023-2024
 #
 # Authors: The OpenBioSim Team <team@openbiosim.org>
 #

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -180,6 +180,7 @@ class Dynamics:
             if equilibration
             else self._config.perturbable_constraint,
             include_constrained_energies=self._config.include_constrained_energies,
+            swap_end_states=self._config.swap_end_states,
             vacuum=not self._has_space,
             map=map,
         )
@@ -207,6 +208,7 @@ class Dynamics:
                     vacuum=not self._has_space,
                     perturbable_constraint=perturbable_constraint,
                     include_constrained_energies=self._config.include_constrained_energies,
+                    swap_end_states=self._config.swap_end_states,
                     map=self._config._extra_args,
                 )
                 m.run()
@@ -225,6 +227,7 @@ class Dynamics:
                     vacuum=not self._has_space,
                     perturbable_constraint=perturbable_constraint,
                     include_constrained_energies=self._config.include_constrained_energies,
+                    swap_end_states=self._config.swap_end_states,
                     map=self._config._extra_args,
                 )
                 m.run()

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -277,6 +277,8 @@ class Runner:
         if not isinstance(config2, dict):
             raise TypeError("'config2' must be of type 'dict'")
 
+        from sire.units import GeneralUnit as _GeneralUnit
+
         # Define the subset of settings that are allowed to change after restart
         allowed_diffs = [
             "runtime",
@@ -303,12 +305,20 @@ class Runner:
         ]
         for key in config1.keys():
             if key not in allowed_diffs:
+                # Extract the config values.
+                v1 = config1[key]
+                v2 = config2[key]
+
+                # Convert GeneralUnits to strings for comparison.
+                if isinstance(v1, _GeneralUnit):
+                    v1 = str(v1)
+                if isinstance(v2, _GeneralUnit):
+                    v2 = str(v2)
+
                 # If one is from sire and the other is not, will raise error even though they are the same
-                if (config1[key] == None and config2[key] == False) or (
-                    config2[key] == None and config1[key] == False
-                ):
+                if (v1 == None and v2 == False) or (v2 == None and v1 == False):
                     continue
-                elif config1[key] != config2[key]:
+                elif v1 != v2:
                     raise ValueError(
                         f"{key} has changed since the last run. This is not allowed when using the restart option."
                     )

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -99,6 +99,7 @@ class Runner:
         if self._config.somd1_compatibility:
             from ._somd1 import _apply_somd1_pert
 
+            _logger.info("Applying SOMD1 perturbation compatibility.")
             self._system = _apply_somd1_pert(self._system)
 
         # Check for a periodic space.

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -95,6 +95,12 @@ class Runner:
             raise TypeError("'config' must be of type 'somd2.config.Config'")
         self._config = config
 
+        # If we're running with somd1 compatibility, then modify the merged molecule.
+        if self._config.somd1_compatibility:
+            from ._somd1 import _apply_somd1_pert
+
+            self._system = _apply_somd1_pert(self._system)
+
         # Check for a periodic space.
         self._check_space()
 

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -1,7 +1,7 @@
 ######################################################################
 # SOMD2: GPU accelerated alchemical free-energy engine.
 #
-# Copyright: 2023
+# Copyright: 2023-2024
 #
 # Authors: The OpenBioSim Team <team@openbiosim.org>
 #

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -23,6 +23,7 @@ __all__ = ["Runner"]
 
 import platform as _platform
 
+from sire import morph as _morph
 from sire import stream as _stream
 from sire.system import System as _System
 
@@ -87,8 +88,7 @@ class Runner:
             raise KeyError("No perturbable molecules in the system")
 
         # Link properties to the lambda = 0 end state.
-        for mol in self._system.molecules("molecule property is_perturbable"):
-            self._system.update(mol.perturbation().link_to_reference().commit())
+        self._system = _morph.link_to_reference(self._system)
 
         # Validate the configuration.
         if not isinstance(config, _Config):

--- a/src/somd2/runner/_somd1.py
+++ b/src/somd2/runner/_somd1.py
@@ -1,0 +1,308 @@
+######################################################################
+# SOMD2: GPU accelerated alchemical free-energy engine.
+#
+# Copyright: 2023-2024
+#
+# Authors: The OpenBioSim Team <team@openbiosim.org>
+#
+# SOMD2 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# SOMD2 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with SOMD2. If not, see <http://www.gnu.org/licenses/>.
+#####################################################################
+
+from sire.system import System as _System
+from sire.legacy.System import System as _LegacySystem
+
+import sire.legacy.CAS as _SireCAS
+import sire.legacy.MM as _SireMM
+import sire.legacy.Mol as _SireMol
+
+
+def _apply_somd1_pert(system):
+    """
+    Applies the somd1 perturbation to the system.
+
+    Parameters
+    ----------
+
+    system : sire.system.System, sire.legacy.System.System
+        The system containing the molecules to be perturbed.
+
+    Returns
+    -------
+
+    system : sire.legacy.System.System
+        The updated system.
+    """
+
+    # Check the system is a Sire system.
+    if not isinstance(system, (_System, _LegacySystem)):
+        raise TypeError(
+            "'system' must of type 'sire.system.System' or 'sire.legacy.System.System'"
+        )
+
+    # Extract the legacy system.
+    if isinstance(system, _LegacySystem):
+        system = _System(system)
+
+    # Search for perturbable molecules.
+    try:
+        pert_mols = system.molecules("property is_perturbable")
+    except KeyError:
+        raise KeyError("No perturbable molecules in the system")
+
+    # Store a dummy element.
+    dummy = _SireMol.Element("Xx")
+
+    for mol in pert_mols:
+        # Get the end state bonded terms.
+
+        # Lambda = 0.
+        bonds0 = mol.property("bond0").potentials()
+        angles0 = mol.property("angle0").potentials()
+        dihedrals0 = mol.property("dihedral0").potentials()
+        impropers0 = mol.property("improper0").potentials()
+
+        # Lambda = 1.
+        bonds1 = mol.property("bond1").potentials()
+        angles1 = mol.property("angle1").potentials()
+        dihedrals1 = mol.property("dihedral1").potentials()
+        impropers1 = mol.property("improper1").potentials()
+
+        # Get an editable version of the molecule.
+        edit_mol = mol.edit()
+
+        # First process the bonds.
+        new_bonds0 = _SireMM.TwoAtomFunctions(mol.info())
+        new_bonds1 = _SireMM.TwoAtomFunctions(mol.info())
+
+        # Loop over the bonds.
+        for p0, p1 in zip(bonds0, bonds1):
+            # Get the atoms involved in the bond.
+            a00 = p0.atom0()
+            a01 = p0.atom1()
+            a10 = p1.atom0()
+            a11 = p1.atom1()
+
+            # Get the elements of the atoms.
+            e00 = mol[a00].property("element0")
+            e01 = mol[a01].property("element0")
+            e10 = mol[a10].property("element1")
+            e11 = mol[a11].property("element1")
+
+            initial_dummy = e00 == dummy or e01 == dummy
+            final_dummy = e10 == dummy or e11 == dummy
+
+            # If there is a dummy, then set the potential to the opposite state.
+            # This should already be the case, but we explicitly set it here.
+
+            if initial_dummy:
+                new_bonds0.set(a00, a01, p1.function())
+                new_bonds1.set(a10, a11, p1.function())
+            elif final_dummy:
+                new_bonds0.set(a00, a01, p0.function())
+                new_bonds1.set(a10, a11, p0.function())
+            else:
+                new_bonds0.set(a00, a01, p0.function())
+                new_bonds1.set(a10, a11, p1.function())
+
+        # Set the new bonded terms.
+        edit_mol = edit_mol.set_property("bond0", new_bonds0).molecule()
+        edit_mol = edit_mol.set_property("bond1", new_bonds1).molecule()
+
+        # Now process the angles.
+
+        new_angles0 = _SireMM.ThreeAtomFunctions(mol.info())
+        new_angles1 = _SireMM.ThreeAtomFunctions(mol.info())
+
+        # Loop over the angles.
+        for p0, p1 in zip(angles0, angles1):
+            # Get the atoms involved in the angle.
+            a00 = p0.atom0()
+            a01 = p0.atom1()
+            a02 = p0.atom2()
+            a10 = p1.atom0()
+            a11 = p1.atom1()
+            a12 = p1.atom2()
+
+            # Get the elements of the atoms.
+            e00 = mol[a00].property("element0")
+            e01 = mol[a01].property("element0")
+            e02 = mol[a02].property("element0")
+            e10 = mol[a10].property("element1")
+            e11 = mol[a11].property("element1")
+            e12 = mol[a12].property("element1")
+
+            initial_dummy = e00 == dummy or e01 == dummy or e02 == dummy
+            final_dummy = e10 == dummy or e11 == dummy or e12 == dummy
+
+            # If both end states contain a dummy, the use null potentials.
+            if initial_dummy and final_dummy:
+                theta = _SireCAS.Symbol("theta")
+                null_angle = _SireMM.AmberAngle(0.0, theta).to_expression(theta)
+                new_angles0.set(a00, a01, a02, null_angle)
+                new_angles1.set(a10, a11, a12, null_angle)
+            # If the initial state contains a dummy, then use the potential from the final state.
+            # This should already be the case, but we explicitly set it here.
+            elif initial_dummy:
+                new_angles0.set(a00, a01, a02, p1.function())
+                new_angles1.set(a10, a11, a12, p1.function())
+            # If the final state contains a dummy, then use the potential from the initial state.
+            # This should already be the case, but we explicitly set it here.
+            elif final_dummy:
+                new_angles0.set(a00, a01, a02, p0.function())
+                new_angles1.set(a10, a11, a12, p0.function())
+            # Otherwise, use the potentials from the initial and final states.
+            else:
+                new_angles0.set(a00, a01, a02, p0.function())
+                new_angles1.set(a10, a11, a12, p1.function())
+
+        # Set the new angle terms.
+        edit_mol = edit_mol.set_property("angle0", new_angles0).molecule()
+        edit_mol = edit_mol.set_property("angle1", new_angles1).molecule()
+
+        # Now process the dihedrals.
+
+        new_dihedrals0 = _SireMM.FourAtomFunctions(mol.info())
+        new_dihedrals1 = _SireMM.FourAtomFunctions(mol.info())
+
+        # Loop over the dihedrals.
+        for p0, p1 in zip(dihedrals0, dihedrals1):
+            # Get the atoms involved in the dihedral.
+            a00 = p0.atom0()
+            a01 = p0.atom1()
+            a02 = p0.atom2()
+            a03 = p0.atom3()
+            a10 = p1.atom0()
+            a11 = p1.atom1()
+            a12 = p1.atom2()
+            a13 = p1.atom3()
+
+            # Get the elements of the atoms.
+            e00 = mol[a00].property("element0")
+            e01 = mol[a01].property("element0")
+            e02 = mol[a02].property("element0")
+            e03 = mol[a03].property("element0")
+            e10 = mol[a10].property("element1")
+            e11 = mol[a11].property("element1")
+            e12 = mol[a12].property("element1")
+            e13 = mol[a13].property("element1")
+
+            initial_dummy = e00 == dummy or e01 == dummy or e02 == dummy or e03 == dummy
+            final_dummy = e10 == dummy or e11 == dummy or e12 == dummy or e13 == dummy
+
+            # If both end states contain a dummy, the use null potentials.
+            if initial_dummy and final_dummy:
+                phi = _SireCAS.Symbol("phi")
+                null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
+                new_dihedrals0.set(a00, a01, a02, a03, null_dihedral)
+                new_dihedrals1.set(a10, a11, a12, a13, null_dihedral)
+            elif initial_dummy:
+                # If all the atoms are dummy, then use the potential from the final state.
+                if e10 == dummy and e11 == dummy and e12 == dummy and e13 == dummy:
+                    new_dihedrals0.set(a00, a01, a02, a03, p1.function())
+                    new_dihedrals1.set(a10, a11, a12, a13, p1.function())
+                # Otherwise, zero the potential.
+                else:
+                    phi = _SireCAS.Symbol("phi")
+                    null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
+                    new_dihedrals0.set(a00, a01, a02, a03, null_dihedral)
+                    new_dihedrals1.set(a10, a11, a12, a13, p1.function())
+            elif final_dummy:
+                # If all the atoms are dummy, then use the potential from the initial state.
+                if e00 == dummy and e01 == dummy and e02 == dummy and e03 == dummy:
+                    new_dihedrals0.set(a00, a01, a02, a03, p0.function())
+                    new_dihedrals1.set(a10, a11, a12, a13, p0.function())
+                # Otherwise, zero the potential.
+                else:
+                    phi = _SireCAS.Symbol("phi")
+                    null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
+                    new_dihedrals0.set(a00, a01, a02, a03, p0.function())
+                    new_dihedrals1.set(a10, a11, a12, a13, null_dihedral)
+            else:
+                new_dihedrals0.set(a00, a01, a02, a03, p0.function())
+                new_dihedrals1.set(a10, a11, a12, a13, p1.function())
+
+        # Set the new dihedral terms.
+        edit_mol = edit_mol.set_property("dihedral0", new_dihedrals0).molecule()
+        edit_mol = edit_mol.set_property("dihedral1", new_dihedrals1).molecule()
+
+        # Now process the impropers.
+
+        new_impropers0 = _SireMM.FourAtomFunctions(mol.info())
+        new_impropers1 = _SireMM.FourAtomFunctions(mol.info())
+
+        # Loop over the impropers.
+        for p0, p1 in zip(impropers0, impropers1):
+            # Get the atoms involved in the improper.
+            a00 = p0.atom0()
+            a01 = p0.atom1()
+            a02 = p0.atom2()
+            a03 = p0.atom3()
+            a10 = p1.atom0()
+            a11 = p1.atom1()
+            a12 = p1.atom2()
+            a13 = p1.atom3()
+
+            # Get the elements of the atoms.
+            e00 = mol[a00].property("element0")
+            e01 = mol[a01].property("element0")
+            e02 = mol[a02].property("element0")
+            e03 = mol[a03].property("element0")
+            e10 = mol[a10].property("element1")
+            e11 = mol[a11].property("element1")
+            e12 = mol[a12].property("element1")
+            e13 = mol[a13].property("element1")
+
+            initial_dummy = e00 == dummy or e01 == dummy or e02 == dummy or e03 == dummy
+            final_dummy = e10 == dummy or e11 == dummy or e12 == dummy or e13 == dummy
+
+            if initial_dummy and final_dummy:
+                phi = _SireCAS.Symbol("phi")
+                null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
+                new_impropers0.set(a00, a01, a02, a03, null_dihedral)
+                new_impropers1.set(a10, a11, a12, a13, null_dihedral)
+            elif initial_dummy:
+                # If all the atoms are dummy, then use the potential from the final state.
+                if e10 == dummy and e11 == dummy and e12 == dummy and e13 == dummy:
+                    new_impropers0.set(a00, a01, a02, a03, p1.function())
+                    new_impropers1.set(a10, a11, a12, a13, p1.function())
+                # Otherwise, zero the potential.
+                else:
+                    phi = _SireCAS.Symbol("phi")
+                    null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
+                    new_impropers0.set(a00, a01, a02, a03, null_dihedral)
+                    new_impropers1.set(a10, a11, a12, a13, p1.function())
+            elif final_dummy:
+                # If all the atoms are dummy, then use the potential from the initial state.
+                if e00 == dummy and e01 == dummy and e02 == dummy and e03 == dummy:
+                    new_impropers0.set(a00, a01, a02, a03, p0.function())
+                    new_impropers1.set(a10, a11, a12, a13, p0.function())
+                # Otherwise, zero the potential.
+                else:
+                    phi = _SireCAS.Symbol("phi")
+                    null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
+                    new_impropers0.set(a00, a01, a02, a03, p0.function())
+                    new_impropers1.set(a10, a11, a12, a13, null_dihedral)
+            else:
+                new_impropers0.set(a00, a01, a02, a03, p0.function())
+                new_impropers1.set(a10, a11, a12, a13, p1.function())
+
+        # Set the new improper terms.
+        edit_mol = edit_mol.set_property("improper0", new_impropers0).molecule()
+        edit_mol = edit_mol.set_property("improper1", new_impropers1).molecule()
+
+        # Commit the changes and update the molecule in the system.
+        system.update(edit_mol.commit())
+
+    # Return the updated system.
+    return system

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,12 @@ import sire as sr
 @pytest.fixture(scope="session")
 def ethane_methanol():
     mols = sr.load(sr.expand(sr.tutorial_url, "merged_molecule.s3"))
-    for mol in mols.molecules("molecule property is_perturbable"):
-        mols.update(mol.perturbation().link_to_reference().commit())
+    mols = sr.morph.link_to_reference(mols)
     return mols
 
 
 @pytest.fixture(scope="session")
 def ethane_methanol_hmr():
     mols = sr.load(sr.expand(sr.tutorial_url, "merged_molecule_hmr.s3"))
-    for mol in mols.molecules("molecule property is_perturbable"):
-        mols.update(mol.perturbation().link_to_reference().commit())
+    mols = sr.morph.link_to_reference(mols)
     return mols

--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -69,7 +69,10 @@ def test_dynamics_options():
         assert config_inp.constraint.lower() == d.constraint().lower()
 
         # Perturbable_constraint.
-        assert config_inp.perturbable_constraint.lower() == d.perturbable_constraint().lower()
+        assert (
+            config_inp.perturbable_constraint.lower()
+            == d.perturbable_constraint().lower()
+        )
 
         # Integrator.
         assert config_inp.integrator.lower().replace(

--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -68,6 +68,9 @@ def test_dynamics_options():
         # Constraint.
         assert config_inp.constraint.lower() == d.constraint().lower()
 
+        # Perturbable_constraint.
+        assert config_inp.perturbable_constraint.lower() == d.perturbable_constraint().lower()
+
         # Integrator.
         assert config_inp.integrator.lower().replace(
             "_", ""


### PR DESCRIPTION
This PR adds support for a `somd1` "compatibility" mode. This ensures that bonded terms in the merge molecule are modified so that the perturbation is consistent with the default that is used for `somd1`, where modifications are made via the "pert" file. For consistency, the water topology is also switched to AMBER format when using compatibility mode. This ensures that _exact_ same solvent parameters are used. The detection of the water topology is crude, but should cover all default cases we require for `somd1` comparisons. (This isn't meant to be a long-lived feature.)

The PR also exposes some addition Sire dynamics keyword arguments that have been added, e.g. the `com_reset_frequency` and `dynamic_constraints`. It also fixes a few minor bugs where keyword arguments weren't properly passed through when instantiating a dynamics driver for a lambda window.

I'll create a new feature branch to work on a `somd-freenrg` CLI to driver `somd2`. This should be pretty straightforward, although I'm not sure if we currently support _all_ of the existing `somd1` options. (Perhaps those related to ABFE restraints, etc., although they should be easy to add once Finlay's work is merged in.)