### PR TITLE
Fix issue #22

### DIFF
--- a/src/somd2/runner/_somd1.py
+++ b/src/somd2/runner/_somd1.py
@@ -539,10 +539,10 @@ def _has_dummy(mol, idxs, is_lambda1=False):
     Parameters
     ----------
 
-    mol : Sire.Mol.Molecule
+    mol : sire.legacy.Mol.Molecule
         The molecule.
 
-    idxs : [AtomIdx]
+    idxs : [sire.legacy.Mol.AtomIdx]
         A list of atom indices.
 
     is_lambda1 : bool
@@ -578,10 +578,10 @@ def _is_dummy(mol, idxs, is_lambda1=False):
     Parameters
     ----------
 
-    mol : Sire.Mol.Molecule
+    mol : sire.legacy.Mol.Molecule
         The molecule.
 
-    idxs : [AtomIdx]
+    idxs : [sire.legacy.Mol.AtomIdx]
         A list of atom indices.
 
     is_lambda1 : bool

--- a/src/somd2/runner/_somd1.py
+++ b/src/somd2/runner/_somd1.py
@@ -64,238 +64,462 @@ def _apply_somd1_pert(system):
     dummy = _SireMol.Element("Xx")
 
     for mol in pert_mols:
-        # Get the end state bonded terms.
-
-        # Lambda = 0.
-        bonds0 = mol.property("bond0").potentials()
-        angles0 = mol.property("angle0").potentials()
-        dihedrals0 = mol.property("dihedral0").potentials()
-        impropers0 = mol.property("improper0").potentials()
-
-        # Lambda = 1.
-        bonds1 = mol.property("bond1").potentials()
-        angles1 = mol.property("angle1").potentials()
-        dihedrals1 = mol.property("dihedral1").potentials()
-        impropers1 = mol.property("improper1").potentials()
+        # Store the molecule info.
+        info = mol.info()
 
         # Get an editable version of the molecule.
         edit_mol = mol.edit()
 
+        ##########################
         # First process the bonds.
+        ##########################
+
         new_bonds0 = _SireMM.TwoAtomFunctions(mol.info())
         new_bonds1 = _SireMM.TwoAtomFunctions(mol.info())
 
-        # Loop over the bonds.
-        for p0, p1 in zip(bonds0, bonds1):
-            # Get the atoms involved in the bond.
-            a00 = p0.atom0()
-            a01 = p0.atom1()
-            a10 = p1.atom0()
-            a11 = p1.atom1()
+        # Extract the bonds at lambda = 0 and 1.
+        bonds0 = mol.property("bond0").potentials()
+        bonds1 = mol.property("bond1").potentials()
 
-            # Get the elements of the atoms.
-            e00 = mol[a00].property("element0")
-            e01 = mol[a01].property("element0")
-            e10 = mol[a10].property("element1")
-            e11 = mol[a11].property("element1")
+        # Dictionaries to store the BondIDs at lambda = 0 and 1.
+        bonds0_idx = {}
+        bonds1_idx = {}
 
-            initial_dummy = e00 == dummy or e01 == dummy
-            final_dummy = e10 == dummy or e11 == dummy
+        # Loop over all bonds at lambda = 0.
+        for idx, bond in enumerate(bonds0):
+            # Get the AtomIdx for the atoms in the bond.
+            idx0 = info.atom_idx(bond.atom0())
+            idx1 = info.atom_idx(bond.atom1())
+
+            # Create the BondID.
+            bond_id = _SireMol.BondID(idx0, idx1)
+
+            # Add to the list of ids.
+            bonds0_idx[bond_id] = idx
+
+        # Loop over all bonds at lambda = 1.
+        for idx, bond in enumerate(bonds1):
+            # Get the AtomIdx for the atoms in the bond.
+            idx0 = info.atom_idx(bond.atom0())
+            idx1 = info.atom_idx(bond.atom1())
+
+            # Create the BondID.
+            bond_id = _SireMol.BondID(idx0, idx1)
+
+            # Add to the list of ids.
+            if bond_id.mirror() in bonds0_idx:
+                bonds1_idx[bond_id.mirror()] = idx
+            else:
+                bonds1_idx[bond_id] = idx
+
+        # Now work out the BondIDs that are unique at lambda = 0 and 1
+        # as well as those that are shared.
+        bonds0_unique_idx = {}
+        bonds1_unique_idx = {}
+        bonds_shared_idx = {}
+
+        # lambda = 0.
+        for idx in bonds0_idx.keys():
+            if idx not in bonds1_idx.keys():
+                bonds0_unique_idx[idx] = bonds0_idx[idx]
+            else:
+                bonds_shared_idx[idx] = (bonds0_idx[idx], bonds1_idx[idx])
+
+        # lambda = 1.
+        for idx in bonds1_idx.keys():
+            if idx not in bonds0_idx.keys():
+                bonds1_unique_idx[idx] = bonds1_idx[idx]
+            elif idx not in bonds_shared_idx.keys():
+                bonds_shared_idx[idx] = (bonds0_idx[idx], bonds1_idx[idx])
+
+        # Loop over the shared bonds.
+        for idx0, idx1 in bonds_shared_idx.values():
+            # Get the bond potentials.
+            p0 = bonds0[idx0]
+            p1 = bonds1[idx1]
+
+            # Get the AtomIdx for the atoms in the angle.
+            idx0 = p0.atom0()
+            idx1 = p0.atom1()
+
+            # Check whether a dummy atoms are present in the lambda = 0
+            # and lambda = 1 states.
+            initial_dummy = _has_dummy(mol, [idx0, idx1])
+            final_dummy = _has_dummy(mol, [idx0, idx1], True)
 
             # If there is a dummy, then set the potential to the opposite state.
             # This should already be the case, but we explicitly set it here.
 
             if initial_dummy:
-                new_bonds0.set(a00, a01, p1.function())
-                new_bonds1.set(a10, a11, p1.function())
+                new_bonds0.set(idx0, idx1, p1.function())
+                new_bonds1.set(idx0, idx1, p1.function())
             elif final_dummy:
-                new_bonds0.set(a00, a01, p0.function())
-                new_bonds1.set(a10, a11, p0.function())
+                new_bonds0.set(idx0, idx1, p0.function())
+                new_bonds1.set(idx0, idx1, p0.function())
             else:
-                new_bonds0.set(a00, a01, p0.function())
-                new_bonds1.set(a10, a11, p1.function())
+                new_bonds0.set(idx0, idx1, p0.function())
+                new_bonds1.set(idx0, idx1, p1.function())
 
         # Set the new bonded terms.
         edit_mol = edit_mol.set_property("bond0", new_bonds0).molecule()
         edit_mol = edit_mol.set_property("bond1", new_bonds1).molecule()
 
+        #########################
         # Now process the angles.
+        #########################
 
         new_angles0 = _SireMM.ThreeAtomFunctions(mol.info())
         new_angles1 = _SireMM.ThreeAtomFunctions(mol.info())
 
+        # Extract the angles at lambda = 0 and 1.
+        angles0 = mol.property("angle0").potentials()
+        angles1 = mol.property("angle1").potentials()
+
+        # Dictionaries to store the AngleIDs at lambda = 0 and 1.
+        angles0_idx = {}
+        angles1_idx = {}
+
+        # Loop over all angles at lambda = 0.
+        for idx, angle in enumerate(angles0):
+            # Get the AtomIdx for the atoms in the angle.
+            idx0 = info.atom_idx(angle.atom0())
+            idx1 = info.atom_idx(angle.atom1())
+            idx2 = info.atom_idx(angle.atom2())
+
+            # Create the AngleID.
+            angle_id = _SireMol.AngleID(idx0, idx1, idx2)
+
+            # Add to the list of ids.
+            angles0_idx[angle_id] = idx
+
+        # Loop over all angles at lambda = 1.
+        for idx, angle in enumerate(angles1):
+            # Get the AtomIdx for the atoms in the angle.
+            idx0 = info.atom_idx(angle.atom0())
+            idx1 = info.atom_idx(angle.atom1())
+            idx2 = info.atom_idx(angle.atom2())
+
+            # Create the AngleID.
+            angle_id = _SireMol.AngleID(idx0, idx1, idx2)
+
+            # Add to the list of ids.
+            if angle_id.mirror() in angles0_idx:
+                angles1_idx[angle_id.mirror()] = idx
+            else:
+                angles1_idx[angle_id] = idx
+
+        # Now work out the AngleIDs that are unique at lambda = 0 and 1
+        # as well as those that are shared.
+        angles0_unique_idx = {}
+        angles1_unique_idx = {}
+        angles_shared_idx = {}
+
+        # lambda = 0.
+        for idx in angles0_idx.keys():
+            if idx not in angles1_idx.keys():
+                angles0_unique_idx[idx] = angles0_idx[idx]
+            else:
+                angles_shared_idx[idx] = (angles0_idx[idx], angles1_idx[idx])
+
+        # lambda = 1.
+        for idx in angles1_idx.keys():
+            if idx not in angles0_idx.keys():
+                angles1_unique_idx[idx] = angles1_idx[idx]
+            elif idx not in angles_shared_idx.keys():
+                angles_shared_idx[idx] = (angles0_idx[idx], angles1_idx[idx])
+
         # Loop over the angles.
-        for p0, p1 in zip(angles0, angles1):
-            # Get the atoms involved in the angle.
-            a00 = p0.atom0()
-            a01 = p0.atom1()
-            a02 = p0.atom2()
-            a10 = p1.atom0()
-            a11 = p1.atom1()
-            a12 = p1.atom2()
+        for idx0, idx1 in angles_shared_idx.values():
+            # Get the angle potentials.
+            p0 = angles0[idx0]
+            p1 = angles1[idx1]
 
-            # Get the elements of the atoms.
-            e00 = mol[a00].property("element0")
-            e01 = mol[a01].property("element0")
-            e02 = mol[a02].property("element0")
-            e10 = mol[a10].property("element1")
-            e11 = mol[a11].property("element1")
-            e12 = mol[a12].property("element1")
+            # Get the AtomIdx for the atoms in the angle.
+            idx0 = p0.atom0()
+            idx1 = p0.atom1()
+            idx2 = p0.atom2()
 
-            initial_dummy = e00 == dummy or e01 == dummy or e02 == dummy
-            final_dummy = e10 == dummy or e11 == dummy or e12 == dummy
+            # Check whether a dummy atoms are present in the lambda = 0
+            # and lambda = 1 states.
+            initial_dummy = _has_dummy(mol, [idx0, idx1, idx2])
+            final_dummy = _has_dummy(mol, [idx0, idx1, idx2], True)
 
             # If both end states contain a dummy, the use null potentials.
             if initial_dummy and final_dummy:
                 theta = _SireCAS.Symbol("theta")
                 null_angle = _SireMM.AmberAngle(0.0, theta).to_expression(theta)
-                new_angles0.set(a00, a01, a02, null_angle)
-                new_angles1.set(a10, a11, a12, null_angle)
+                new_angles0.set(idx0, idx1, idx2, null_angle)
+                new_angles1.set(idx0, idx1, idx2, null_angle)
             # If the initial state contains a dummy, then use the potential from the final state.
             # This should already be the case, but we explicitly set it here.
             elif initial_dummy:
-                new_angles0.set(a00, a01, a02, p1.function())
-                new_angles1.set(a10, a11, a12, p1.function())
+                new_angles0.set(idx0, idx1, idx2, p1.function())
+                new_angles1.set(idx0, idx1, idx2, p1.function())
             # If the final state contains a dummy, then use the potential from the initial state.
             # This should already be the case, but we explicitly set it here.
             elif final_dummy:
-                new_angles0.set(a00, a01, a02, p0.function())
-                new_angles1.set(a10, a11, a12, p0.function())
+                new_angles0.set(idx0, idx1, idx2, p0.function())
+                new_angles1.set(idx0, idx1, idx2, p0.function())
             # Otherwise, use the potentials from the initial and final states.
             else:
-                new_angles0.set(a00, a01, a02, p0.function())
-                new_angles1.set(a10, a11, a12, p1.function())
+                new_angles0.set(idx0, idx1, idx2, p0.function())
+                new_angles1.set(idx0, idx1, idx2, p1.function())
 
         # Set the new angle terms.
         edit_mol = edit_mol.set_property("angle0", new_angles0).molecule()
         edit_mol = edit_mol.set_property("angle1", new_angles1).molecule()
 
+        ############################
         # Now process the dihedrals.
+        ############################
 
         new_dihedrals0 = _SireMM.FourAtomFunctions(mol.info())
         new_dihedrals1 = _SireMM.FourAtomFunctions(mol.info())
 
+        # Extract the dihedrals at lambda = 0 and 1.
+        dihedrals0 = mol.property("dihedral0").potentials()
+        dihedrals1 = mol.property("dihedral1").potentials()
+
+        # Dictionaries to store the DihedralIDs at lambda = 0 and 1.
+        dihedrals0_idx = {}
+        dihedrals1_idx = {}
+
+        # Loop over all dihedrals at lambda = 0.
+        for idx, dihedral in enumerate(dihedrals0):
+            # Get the AtomIdx for the atoms in the dihedral.
+            idx0 = info.atom_idx(dihedral.atom0())
+            idx1 = info.atom_idx(dihedral.atom1())
+            idx2 = info.atom_idx(dihedral.atom2())
+            idx3 = info.atom_idx(dihedral.atom3())
+
+            # Create the DihedralID.
+            dihedral_id = _SireMol.DihedralID(idx0, idx1, idx2, idx3)
+
+            # Add to the list of ids.
+            dihedrals0_idx[dihedral_id] = idx
+
+        # Loop over all dihedrals at lambda = 1.
+        for idx, dihedral in enumerate(dihedrals1):
+            # Get the AtomIdx for the atoms in the dihedral.
+            idx0 = info.atom_idx(dihedral.atom0())
+            idx1 = info.atom_idx(dihedral.atom1())
+            idx2 = info.atom_idx(dihedral.atom2())
+            idx3 = info.atom_idx(dihedral.atom3())
+
+            # Create the DihedralID.
+            dihedral_id = _SireMol.DihedralID(idx0, idx1, idx2, idx3)
+
+            # Add to the list of ids.
+            if dihedral_id.mirror() in dihedrals0_idx:
+                dihedrals1_idx[dihedral_id.mirror()] = idx
+            else:
+                dihedrals1_idx[dihedral_id] = idx
+
+        # Now work out the DihedralIDs that are unique at lambda = 0 and 1
+        # as well as those that are shared.
+        dihedrals0_unique_idx = {}
+        dihedrals1_unique_idx = {}
+        dihedrals_shared_idx = {}
+
+        # lambda = 0.
+        for idx in dihedrals0_idx.keys():
+            if idx not in dihedrals1_idx.keys():
+                dihedrals0_unique_idx[idx] = dihedrals0_idx[idx]
+            else:
+                dihedrals_shared_idx[idx] = (dihedrals0_idx[idx], dihedrals1_idx[idx])
+
+        # lambda = 1.
+        for idx in dihedrals1_idx.keys():
+            if idx not in dihedrals0_idx.keys():
+                dihedrals1_unique_idx[idx] = dihedrals1_idx[idx]
+            elif idx not in dihedrals_shared_idx.keys():
+                dihedrals_shared_idx[idx] = (dihedrals0_idx[idx], dihedrals1_idx[idx])
+
         # Loop over the dihedrals.
-        for p0, p1 in zip(dihedrals0, dihedrals1):
-            # Get the atoms involved in the dihedral.
-            a00 = p0.atom0()
-            a01 = p0.atom1()
-            a02 = p0.atom2()
-            a03 = p0.atom3()
-            a10 = p1.atom0()
-            a11 = p1.atom1()
-            a12 = p1.atom2()
-            a13 = p1.atom3()
+        for idx0, idx1 in dihedrals_shared_idx.values():
+            # Get the dihedral potentials.
+            p0 = dihedrals0[idx0]
+            p1 = dihedrals1[idx1]
 
-            # Get the elements of the atoms.
-            e00 = mol[a00].property("element0")
-            e01 = mol[a01].property("element0")
-            e02 = mol[a02].property("element0")
-            e03 = mol[a03].property("element0")
-            e10 = mol[a10].property("element1")
-            e11 = mol[a11].property("element1")
-            e12 = mol[a12].property("element1")
-            e13 = mol[a13].property("element1")
+            # Get the AtomIdx for the atoms in the dihedral.
+            idx0 = info.atom_idx(p0.atom0())
+            idx1 = info.atom_idx(p0.atom1())
+            idx2 = info.atom_idx(p0.atom2())
+            idx3 = info.atom_idx(p0.atom3())
 
-            initial_dummy = e00 == dummy or e01 == dummy or e02 == dummy or e03 == dummy
-            final_dummy = e10 == dummy or e11 == dummy or e12 == dummy or e13 == dummy
+            # Whether any atom in each end state is a dummy.
+            has_dummy_initial = _has_dummy(mol, [idx0, idx1, idx2, idx3])
+            has_dummy_final = _has_dummy(mol, [idx0, idx1, idx2, idx3], True)
+
+            # Whether all atoms in each state are dummies.
+            all_dummy_initial = all(_is_dummy(mol, [idx0, idx1, idx2, idx3]))
+            all_dummy_final = all(_is_dummy(mol, [idx0, idx1, idx2, idx3], True))
 
             # If both end states contain a dummy, the use null potentials.
-            if initial_dummy and final_dummy:
+            if has_dummy_initial and has_dummy_final:
                 phi = _SireCAS.Symbol("phi")
                 null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
-                new_dihedrals0.set(a00, a01, a02, a03, null_dihedral)
-                new_dihedrals1.set(a10, a11, a12, a13, null_dihedral)
-            elif initial_dummy:
+                new_dihedrals0.set(idx0, idx1, idx2, idx3, null_dihedral)
+                new_dihedrals1.set(idx0, idx1, idx2, idx3, null_dihedral)
+            elif has_dummy_initial:
                 # If all the atoms are dummy, then use the potential from the final state.
-                if e10 == dummy and e11 == dummy and e12 == dummy and e13 == dummy:
-                    new_dihedrals0.set(a00, a01, a02, a03, p1.function())
-                    new_dihedrals1.set(a10, a11, a12, a13, p1.function())
+                if all_dummy_initial:
+                    new_dihedrals0.set(idx0, idx1, idx2, idx3, p1.function())
+                    new_dihedrals1.set(idx0, idx1, idx2, idx3, p1.function())
                 # Otherwise, zero the potential.
                 else:
                     phi = _SireCAS.Symbol("phi")
                     null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
-                    new_dihedrals0.set(a00, a01, a02, a03, null_dihedral)
-                    new_dihedrals1.set(a10, a11, a12, a13, p1.function())
-            elif final_dummy:
+                    new_dihedrals0.set(idx0, idx1, idx2, idx3, null_dihedral)
+                    new_dihedrals1.set(idx0, idx1, idx2, idx3, p1.function())
+            elif has_dummy_final:
                 # If all the atoms are dummy, then use the potential from the initial state.
-                if e00 == dummy and e01 == dummy and e02 == dummy and e03 == dummy:
-                    new_dihedrals0.set(a00, a01, a02, a03, p0.function())
-                    new_dihedrals1.set(a10, a11, a12, a13, p0.function())
+                if all_dummy_final:
+                    new_dihedrals0.set(idx0, idx1, idx2, idx3, p0.function())
+                    new_dihedrals1.set(idx0, idx1, idx2, idx3, p0.function())
                 # Otherwise, zero the potential.
                 else:
                     phi = _SireCAS.Symbol("phi")
                     null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
-                    new_dihedrals0.set(a00, a01, a02, a03, p0.function())
-                    new_dihedrals1.set(a10, a11, a12, a13, null_dihedral)
+                    new_dihedrals0.set(idx0, idx1, idx2, idx3, p0.function())
+                    new_dihedrals1.set(idx0, idx1, idx2, idx3, null_dihedral)
             else:
-                new_dihedrals0.set(a00, a01, a02, a03, p0.function())
-                new_dihedrals1.set(a10, a11, a12, a13, p1.function())
+                new_dihedrals0.set(idx0, idx1, idx2, idx3, p0.function())
+                new_dihedrals1.set(idx0, idx1, idx2, idx3, p1.function())
 
         # Set the new dihedral terms.
         edit_mol = edit_mol.set_property("dihedral0", new_dihedrals0).molecule()
         edit_mol = edit_mol.set_property("dihedral1", new_dihedrals1).molecule()
 
+        ############################
         # Now process the impropers.
+        ############################
 
         new_impropers0 = _SireMM.FourAtomFunctions(mol.info())
         new_impropers1 = _SireMM.FourAtomFunctions(mol.info())
 
+        # Extract the impropers at lambda = 0 and 1.
+        impropers0 = mol.property("improper0").potentials()
+        impropers1 = mol.property("improper1").potentials()
+
+        # Dictionaries to store the ImproperIDs at lambda = 0 and 1.
+        impropers0_idx = {}
+        impropers1_idx = {}
+
+        # Loop over all impropers at lambda = 0.
+        for idx, improper in enumerate(impropers0):
+            # Get the AtomIdx for the atoms in the improper.
+            idx0 = info.atom_idx(improper.atom0())
+            idx1 = info.atom_idx(improper.atom1())
+            idx2 = info.atom_idx(improper.atom2())
+            idx3 = info.atom_idx(improper.atom3())
+
+            # Create the ImproperID.
+            improper_id = _SireMol.ImproperID(idx0, idx1, idx2, idx3)
+
+            # Add to the list of ids.
+            impropers0_idx[improper_id] = idx
+
+        # Loop over all impropers at lambda = 1.
+        for idx, improper in enumerate(impropers1):
+            # Get the AtomIdx for the atoms in the improper.
+            idx0 = info.atom_idx(improper.atom0())
+            idx1 = info.atom_idx(improper.atom1())
+            idx2 = info.atom_idx(improper.atom2())
+            idx3 = info.atom_idx(improper.atom3())
+
+            # Create the ImproperID.
+            improper_id = _SireMol.ImproperID(idx0, idx1, idx2, idx3)
+
+            # Add to the list of ids.
+            # You cannot mirror an improper!
+            impropers1_idx[improper_id] = idx
+
+        # Now work out the ImproperIDs that are unique at lambda = 0 and 1
+        # as well as those that are shared. Note that the ordering of
+        # impropers is inconsistent between molecular topology formats so
+        # we test all permutations of atom ordering to find matches. This
+        # is achieved using the ImproperID.equivalent() method.
+        impropers0_unique_idx = {}
+        impropers1_unique_idx = {}
+        impropers_shared_idx = {}
+
+        # lambda = 0.
+        for idx0 in impropers0_idx.keys():
+            for idx1 in impropers1_idx.keys():
+                if idx0.equivalent(idx1):
+                    impropers_shared_idx[idx0] = (
+                        impropers0_idx[idx0],
+                        impropers1_idx[idx1],
+                    )
+                    break
+            else:
+                impropers0_unique_idx[idx0] = impropers0_idx[idx0]
+
+        # lambda = 1.
+        for idx1 in impropers1_idx.keys():
+            for idx0 in impropers0_idx.keys():
+                if idx1.equivalent(idx0):
+                    # Don't store duplicates.
+                    if not idx0 in impropers_shared_idx.keys():
+                        impropers_shared_idx[idx1] = (
+                            impropers0_idx[idx0],
+                            impropers1_idx[idx1],
+                        )
+                    break
+            else:
+                impropers1_unique_idx[idx1] = impropers1_idx[idx1]
+
         # Loop over the impropers.
-        for p0, p1 in zip(impropers0, impropers1):
-            # Get the atoms involved in the improper.
-            a00 = p0.atom0()
-            a01 = p0.atom1()
-            a02 = p0.atom2()
-            a03 = p0.atom3()
-            a10 = p1.atom0()
-            a11 = p1.atom1()
-            a12 = p1.atom2()
-            a13 = p1.atom3()
+        for idx0, idx1 in impropers_shared_idx.values():
+            # Get the improper potentials.
+            p0 = impropers0[idx0]
+            p1 = impropers1[idx1]
 
-            # Get the elements of the atoms.
-            e00 = mol[a00].property("element0")
-            e01 = mol[a01].property("element0")
-            e02 = mol[a02].property("element0")
-            e03 = mol[a03].property("element0")
-            e10 = mol[a10].property("element1")
-            e11 = mol[a11].property("element1")
-            e12 = mol[a12].property("element1")
-            e13 = mol[a13].property("element1")
+            # Get the AtomIdx for the atoms in the dihedral.
+            idx0 = info.atom_idx(p0.atom0())
+            idx1 = info.atom_idx(p0.atom1())
+            idx2 = info.atom_idx(p0.atom2())
+            idx3 = info.atom_idx(p0.atom3())
 
-            initial_dummy = e00 == dummy or e01 == dummy or e02 == dummy or e03 == dummy
-            final_dummy = e10 == dummy or e11 == dummy or e12 == dummy or e13 == dummy
+            # Whether any atom in each end state is a dummy.
+            has_dummy_initial = _has_dummy(mol, [idx0, idx1, idx2, idx3])
+            has_dummy_final = _has_dummy(mol, [idx0, idx1, idx2, idx3], True)
 
-            if initial_dummy and final_dummy:
+            # Whether all atoms in each state are dummies.
+            all_dummy_initial = all(_is_dummy(mol, [idx0, idx1, idx2, idx3]))
+            all_dummy_final = all(_is_dummy(mol, [idx0, idx1, idx2, idx3], True))
+
+            if has_dummy_initial and has_dummy_final:
                 phi = _SireCAS.Symbol("phi")
                 null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
-                new_impropers0.set(a00, a01, a02, a03, null_dihedral)
-                new_impropers1.set(a10, a11, a12, a13, null_dihedral)
-            elif initial_dummy:
+                new_impropers0.set(idx0, idx1, idx2, idx3, null_dihedral)
+                new_impropers1.set(idx0, idx1, idx2, idx3, null_dihedral)
+            elif has_dummy_initial:
                 # If all the atoms are dummy, then use the potential from the final state.
-                if e10 == dummy and e11 == dummy and e12 == dummy and e13 == dummy:
-                    new_impropers0.set(a00, a01, a02, a03, p1.function())
-                    new_impropers1.set(a10, a11, a12, a13, p1.function())
+                if all_dummy_initial:
+                    new_impropers0.set(idx0, idx1, idx2, idx3, p1.function())
+                    new_impropers1.set(idx0, idx1, idx2, idx3, p1.function())
                 # Otherwise, zero the potential.
                 else:
                     phi = _SireCAS.Symbol("phi")
                     null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
-                    new_impropers0.set(a00, a01, a02, a03, null_dihedral)
-                    new_impropers1.set(a10, a11, a12, a13, p1.function())
-            elif final_dummy:
+                    new_impropers0.set(idx0, idx1, idx2, idx3, null_dihedral)
+                    new_impropers1.set(idx0, idx1, idx2, idx3, p1.function())
+            elif has_dummy_final:
                 # If all the atoms are dummy, then use the potential from the initial state.
-                if e00 == dummy and e01 == dummy and e02 == dummy and e03 == dummy:
-                    new_impropers0.set(a00, a01, a02, a03, p0.function())
-                    new_impropers1.set(a10, a11, a12, a13, p0.function())
+                if all_dummy_final:
+                    new_impropers0.set(idx0, idx1, idx2, idx3, p0.function())
+                    new_impropers1.set(idx0, idx1, idx2, idx3, p0.function())
                 # Otherwise, zero the potential.
                 else:
                     phi = _SireCAS.Symbol("phi")
                     null_dihedral = _SireMM.AmberDihedral(0.0, phi).to_expression(phi)
-                    new_impropers0.set(a00, a01, a02, a03, p0.function())
-                    new_impropers1.set(a10, a11, a12, a13, null_dihedral)
+                    new_impropers0.set(idx0, idx1, idx2, idx3, p0.function())
+                    new_impropers1.set(idx0, idx1, idx2, idx3, null_dihedral)
             else:
-                new_impropers0.set(a00, a01, a02, a03, p0.function())
-                new_impropers1.set(a10, a11, a12, a13, p1.function())
+                new_impropers0.set(idx0, idx1, idx2, idx3, p0.function())
+                new_impropers1.set(idx0, idx1, idx2, idx3, p1.function())
 
         # Set the new improper terms.
         edit_mol = edit_mol.set_property("improper0", new_impropers0).molecule()
@@ -306,3 +530,84 @@ def _apply_somd1_pert(system):
 
     # Return the updated system.
     return system
+
+
+def _has_dummy(mol, idxs, is_lambda1=False):
+    """
+    Internal function to check whether any atom is a dummy.
+
+    Parameters
+    ----------
+
+    mol : Sire.Mol.Molecule
+        The molecule.
+
+    idxs : [AtomIdx]
+        A list of atom indices.
+
+    is_lambda1 : bool
+        Whether to check the lambda = 1 state.
+
+    Returns
+    -------
+
+    has_dummy : bool
+        Whether a dummy atom is present.
+    """
+
+    # Set the element property associated with the end state.
+    if is_lambda1:
+        prop = "element1"
+    else:
+        prop = "element0"
+
+    dummy = _SireMol.Element(0)
+
+    # Check whether an of the atoms is a dummy.
+    for idx in idxs:
+        if mol.atom(idx).property(prop) == dummy:
+            return True
+
+    return False
+
+
+def _is_dummy(mol, idxs, is_lambda1=False):
+    """
+    Internal function to return whether each atom is a dummy.
+
+    Parameters
+    ----------
+
+    mol : Sire.Mol.Molecule
+        The molecule.
+
+    idxs : [AtomIdx]
+        A list of atom indices.
+
+    is_lambda1 : bool
+        Whether to check the lambda = 1 state.
+
+    Returns
+    -------
+
+    is_dummy : [bool]
+        Whether each atom is a dummy.
+    """
+
+    # Set the element property associated with the end state.
+    if is_lambda1:
+        prop = "element1"
+    else:
+        prop = "element0"
+
+    # Store a dummy element.
+    dummy = _SireMol.Element(0)
+
+    # Initialise a list to store the state of each atom.
+    is_dummy = []
+
+    # Check whether each of the atoms is a dummy.
+    for idx in idxs:
+        is_dummy.append(mol.atom(idx).property(prop) == dummy)
+
+    return is_dummy


### PR DESCRIPTION
This PR fixes the somd1 compatibility mode by exhaustively searching bonded potentials to find shared terms. Previously I had forgotten that the containers don't preserve order, so matching directly between end states wasn't robust. This has been tested against problematic vacuum perturbations from the hydration free energy test suite and results are now in perfect agreement with somd1.

[closes #22]
