### PR TITLE
Further SOMD1 compatibility updates

### DIFF
--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -158,11 +158,6 @@ class Dynamics:
         else:
             pressure = None
 
-        try:
-            map = self._config._extra_args
-        except:
-            map = None
-
         self._dyn = self._system.dynamics(
             temperature=self._config.temperature,
             pressure=pressure,
@@ -186,7 +181,7 @@ class Dynamics:
             swap_end_states=self._config.swap_end_states,
             com_reset_frequency=self._config.com_reset_frequency,
             vacuum=not self._has_space,
-            map=map,
+            map=self._config._extra_args,
         )
 
     def _minimisation(self, lambda_min=None, perturbable_constraint="none"):
@@ -200,6 +195,7 @@ class Dynamics:
             Lambda value at which to run minimisation, if None run at pre-set
             lambda_val.
         """
+
         if lambda_min is None:
             _logger.info(f"Minimising at {_lam_sym} = {self._lambda_val}")
             try:
@@ -210,6 +206,7 @@ class Dynamics:
                     lambda_value=self._lambda_val,
                     platform=self._config.platform,
                     vacuum=not self._has_space,
+                    constraint=self._config.constraint,
                     perturbable_constraint=perturbable_constraint,
                     include_constrained_energies=self._config.include_constrained_energies,
                     dynamic_constraints=self._config.dynamic_constraints,
@@ -230,6 +227,7 @@ class Dynamics:
                     lambda_value=lambda_min,
                     platform=self._config.platform,
                     vacuum=not self._has_space,
+                    constraint=self._config.constraint,
                     perturbable_constraint=perturbable_constraint,
                     include_constrained_energies=self._config.include_constrained_energies,
                     dynamic_constraints=self._config.dynamic_constraints,

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -94,6 +94,7 @@ class Runner:
         if not isinstance(config, _Config):
             raise TypeError("'config' must be of type 'somd2.config.Config'")
         self._config = config
+        self._config._extra_args = {}
 
         # We're running in SOMD1 compatibility mode.
         if self._config.somd1_compatibility:
@@ -138,8 +139,20 @@ class Runner:
                             "Unable to convert water topology to AMBER format for SOMD1 compatibility."
                         )
 
+            # Only check for light atoms by the maxium end state mass if running
+            # in SOMD1 compatibility mode.
+            if self._config.somd1_compatibility:
+                self._config._extra_args["check_for_h_by_max_mass"] = True
+                self._config._extra_args["check_for_h_by_mass"] = False
+                self._config._extra_args["check_for_h_by_mass"] = False
+                self._config._extra_args["check_for_h_by_element"] = False
+                self._config._extra_args["check_for_h_by_ambertype"] = False
+
         # Check for a periodic space.
         self._check_space()
+
+        # Check the end state contraints.
+        self._check_end_state_constraints()
 
         # Set the lambda values.
         self._lambda_values = [
@@ -234,6 +247,39 @@ class Runner:
                     "Cannot use PME for non-periodic simulations. Using RF cutoff instead."
                 )
                 self._config.cutoff_type = "rf"
+
+    def _check_end_state_constraints(self):
+        """
+        Internal function to check whether the constrants are the same at the two
+        end states.
+        """
+
+        # Assume a single perturbable molecule for now.
+        pert_mol = self._system.molecules("property is_perturbable")[0]
+
+        # Create a dynamics object.
+        d = pert_mol.dynamics(
+            constraint=self._config.constraint,
+            perturbable_constraint=self._config.perturbable_constraint,
+            platform="cpu",
+            map=self._config._extra_args,
+        )
+
+        # Get the constraints at lambda = 0.
+        constraints0 = d.get_constraints()
+
+        # Update to lambda = 1.
+        d.set_lambda(1)
+
+        # Get the constraints at lambda = 1.
+        constraints1 = d.get_constraints()
+
+        # Check for equivalence.
+        for c0, c1 in zip(constraints0, constraints1):
+            if c0 != c1:
+                _logger.info(
+                    f"Constraints are at not the same at {_lam_sym} = 0 and {_lam_sym} = 1."
+                )
 
     def _check_directory(self):
         """
@@ -657,17 +703,15 @@ class Runner:
                     threads_per_worker = (
                         self._config.max_threads // self._config.num_lambda
                     )
-                self._config._extra_args = {"threads": threads_per_worker}
+                self._config._extra_args["threads"] = threads_per_worker
 
             # (Multi-)GPU platform.
             elif self._is_gpu:
                 self.max_workers = len(self._gpu_pool)
-                self._config._extra_args = {}
 
             # All other platforms.
             else:
                 self._max_workers = 1
-                self._config._extra_args = {}
 
             import concurrent.futures as _futures
 
@@ -696,7 +740,7 @@ class Runner:
         # Serial configuration.
         elif self._config.num_lambda is not None:
             if self._config.platform == "cpu":
-                self._config.extra_args = {"threads": self._config.max_threads}
+                self._config._extra_args = {"threads": self._config.max_threads}
             self._lambda_values = [
                 round(i / (self._config.num_lambda - 1), 5)
                 for i in range(0, self._config.num_lambda)


### PR DESCRIPTION
This PR adds the following minor updates for SOMD1 compatibility and testing:

* Check for light atoms in perturbable molecules by the maximum end-state mass only.

* Check that the constraints are the same in both end states and log a message if not.

* I also added a missing `constraint` kwarg to the minimisation.