### PR TITLE
Move pert_file CLI option into Config class

### DIFF
--- a/src/somd2/app/run.py
+++ b/src/somd2/app/run.py
@@ -61,21 +61,13 @@ def cli():
         "or the reference system. If a reference system, then this must be "
         "combined with a perturbation file via the --pert-file argument.",
     )
-    parser.add_argument(
-        "--pert-file",
-        type=str,
-        required=False,
-        help="Path to a file containing the perturbation to apply "
-        "to the reference system.",
-    )
 
     # Parse the arguments into a dictionary.
     args = vars(parser.parse_args())
 
-    # Pop the YAML config, system, and pert file from the arguments dictionary.
+    # Pop the YAML config and system from the arguments dictionary.
     config = args.pop("config")
     system = args.pop("system")
-    pert_file = args.pop("pert_file")
 
     # If set, read the YAML config file.
     if config is not None:
@@ -87,12 +79,9 @@ def cli():
         # will override those in the config.
         args = vars(parser.parse_args(namespace=Namespace(**config)))
 
-        # Re-pop the YAML config, system, and pert file from the arguments
-        # dictionary.
+        # Re-pop the YAML config and system from the arguments dictionary.
         args.pop("config")
         args.pop("system")
-        if pert_file is None:
-            pert_file = args.pop("pert_file")
 
     # Instantiate a Config object to validate the arguments.
     config = Config(**args)
@@ -101,80 +90,8 @@ def cli():
     _logger.info(f"somd2 version: {__version__}")
     _logger.info(f"sire version: {sire_version}+{sire_revisionid}")
 
-    # Try to apply the perturbation to the reference system.
-    if pert_file is not None:
-        _logger.info(f"Applying perturbation to reference system: {pert_file}")
-        system = apply_pert(system, pert_file)
-
     # Instantiate a Runner object to run the simulation.
     runner = Runner(system, config)
 
     # Run the simulation.
     runner.run()
-
-
-def apply_pert(system, pert_file):
-    """
-    Helper function to apply a perturbation to a reference system.
-
-    Parameters
-    ----------
-
-    system: str
-        Path to a stream file containing the reference system.
-
-    pert_file: str
-        Path to a stream file containing the perturbation to apply to the
-        reference system.
-
-    Returns
-    -------
-
-    system: sire.system.System
-        The perturbable system.
-    """
-
-    if not isinstance(system, str):
-        raise TypeError("'system' must be of type 'str'.")
-
-    if not isinstance(pert_file, str):
-        raise TypeError("'pert_file' must be of type 'str'.")
-
-    import os as _os
-
-    if not _os.path.isfile(system):
-        raise FileNotFoundError(f"'{system}' does not exist.")
-
-    if not _os.path.isfile(pert_file):
-        raise FileNotFoundError(f"'{pert_file}' does not exist.")
-
-    from sire import stream as _stream
-    from sire import morph as _morph
-
-    # Load the reference system.
-    try:
-        system = _stream.load(system)
-    except Exception as e:
-        raise ValueError(f"Failed to load the reference 'system': {e}")
-
-    # Get the non-water molecules in the system.
-    non_waters = system["not water"]
-
-    # Try to apply the perturbation to each non-water molecule.
-    is_pert = False
-    for mol in non_waters:
-        try:
-            pert_mol = _morph.create_from_pertfile(mol, pert_file)
-            is_pert = True
-            break
-        except:
-            pass
-
-    if not is_pert:
-        raise ValueError(f"Failed to apply the perturbation in '{pert_file}'.")
-
-    # Replace the reference molecule with the perturbed molecule.
-    system.remove(mol)
-    system.add(pert_mol)
-
-    return system

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -86,7 +86,7 @@ class Config:
         coulomb_power=0.0,
         shift_delta="2A",
         constraint="h_bonds",
-        perturbable_constraint="h_bonds_not_perturbed",
+        perturbable_constraint="bonds_not_heavy_perturbed",
         include_constrained_energies=False,
         dynamic_constraints=True,
         com_reset_frequency=10,

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -107,6 +107,7 @@ class Config:
         write_config=True,
         overwrite=False,
         somd1_compatibility=False,
+        pert_file=None,
     ):
         """
         Constructor.
@@ -243,6 +244,10 @@ class Config:
 
         somd1_compatibility: bool
             Whether to run using a SOMD1 compatible perturbation.
+
+        pert_file: str
+            The path to a SOMD1 perturbation file to apply to the reference system.
+            When set, this will automatically set 'somd1_compatibility' to True.
         """
 
         # Setup logger before doing anything else
@@ -284,6 +289,7 @@ class Config:
         self.run_parallel = run_parallel
         self.restart = restart
         self.somd1_compatibility = somd1_compatibility
+        self.pert_file = pert_file
 
         self.write_config = write_config
 
@@ -1025,6 +1031,25 @@ class Config:
         if not isinstance(somd1_compatibility, bool):
             raise ValueError("'somd1_compatibility' must be of type 'bool'")
         self._somd1_compatibility = somd1_compatibility
+
+    @property
+    def pert_file(self):
+        return self._pert_file
+
+    @pert_file.setter
+    def pert_file(self, pert_file):
+        import os
+
+        if pert_file is not None and not isinstance(pert_file, str):
+            raise TypeError("'pert_file' must be of type 'str'")
+
+        if pert_file is not None and not os.path.exists(pert_file):
+            raise ValueError(f"Perturbation file does not exist: {pert_file}")
+
+        self._pert_file = pert_file
+
+        if pert_file is not None:
+            self._somd1_compatibility = True
 
     @property
     def output_directory(self):

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -703,7 +703,7 @@ class Config:
             perturbable_constraint = perturbable_constraint.lower().replace(" ", "")
             if perturbable_constraint not in self._choices["perturbable_constraint"]:
                 raise ValueError(
-                    f"'perturbable_constrant' not recognised. Valid constraints are: {', '.join(self._choices['constraint'])}"
+                    f"'perturbable_constraint' not recognised. Valid constraints are: {', '.join(self._choices['perturbable_constraint'])}"
                 )
             else:
                 self._perturbable_constraint = perturbable_constraint


### PR DESCRIPTION
This PR moves the `--pert-file` CLI option into the `Config` class so that it is stored to the YAML configuration file. The perturbable system is now created during the runner setup and `somd1_compatibility` is automatically set to `True` when running using a reference state and perturbation file. (As a safety net.)