### PR TITLE
Ensure that Exceptions are Logged When Running in Serial

### DIFF
--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -905,7 +905,7 @@ class Runner:
             # Assumes that device for non-parallel GPU jobs is 0
             else:
                 gpu_num = 0
-                _logger.info("Running {_lam_sym} = {lambda_value} on GPU 0")
+                _logger.info(f"Running {_lam_sym} = {lambda_value} on GPU 0")
             self._initialise_simulation(system, lambda_value, device=gpu_num)
             try:
                 df, lambda_grad, speed = _run(self._sim, is_restart=is_restart)

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -763,8 +763,12 @@ class Runner:
             for lambda_value in self._lambda_values:
                 try:
                     result = self.run_window(lambda_value)
-                except:
+                except Exception as e:
                     result = False
+
+                    _logger.error(
+                        f"Exception raised for {_lam_sym} = {lambda_value}: {e}"
+                    )
                 results.append(result)
 
         else:


### PR DESCRIPTION
SOMD2 was exiting without raising an error when run in serial (the error was raised in `_setup_dynamics`). I've also added a missing f-string. 