### PR TITLE
Make version information more accessible

### DIFF
--- a/src/somd2/__init__.py
+++ b/src/somd2/__init__.py
@@ -30,3 +30,4 @@ del _ProgressBar
 from loguru import logger as _logger
 
 from . import runner
+from ._version import __version__, __version_tuple__

--- a/src/somd2/app/run.py
+++ b/src/somd2/app/run.py
@@ -37,18 +37,9 @@ def cli():
 
     from argparse import Namespace
 
-    from somd2 import _logger
     from somd2.config import Config
-    from somd2.runner import Runner
-
     from somd2.io import yaml_to_dict
-
-    # Store the somd2 version.
-    from somd2._version import __version__
-
-    # Store the sire version.
-    from sire import __version__ as sire_version
-    from sire import __revisionid__ as sire_revisionid
+    from somd2.runner import Runner
 
     # Generate the parser.
     parser = Config._create_parser()
@@ -85,10 +76,6 @@ def cli():
 
     # Instantiate a Config object to validate the arguments.
     config = Config(**args)
-
-    # Log the versions of somd2 and sire.
-    _logger.info(f"somd2 version: {__version__}")
-    _logger.info(f"sire version: {sire_version}+{sire_revisionid}")
 
     # Instantiate a Runner object to run the simulation.
     runner = Runner(system, config)

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -27,12 +27,15 @@ __all__ = ["Config"]
 
 
 from collections.abc import Iterable as _Iterable
-from openmm import Platform as _Platform
 from pathlib import Path as _Path
 
 import sire as _sr
+from openmm import Platform as _Platform
+from sire import __revisionid__ as sire_revisionid
+from sire import __version__ as sire_version
 
 from somd2 import _logger
+from somd2._version import __version__
 
 # List of supported Sire platforms.
 _sire_platforms = _sr.options.Platform.options()
@@ -312,6 +315,10 @@ class Config:
         self.write_config = write_config
 
         self.overwrite = overwrite
+
+        # Log the versions of somd2 and sire.
+        _logger.info(f"somd2 version: {__version__}")
+        _logger.info(f"sire version: {sire_version}+{sire_revisionid}")
 
     def __str__(self):
         """Return a string representation of this object."""


### PR DESCRIPTION
Ensure that the versions of SOMD2 and sire are logged even if SOMD2 is run from a script, and not just through the CLI. Also, ensure that `somd2.__version__` shows the version.