### PR TITLE
Improve versioning

### DIFF
--- a/src/somd2/__init__.py
+++ b/src/somd2/__init__.py
@@ -30,3 +30,30 @@ del _ProgressBar
 from loguru import logger as _logger
 
 from . import runner
+
+# Store the somd2 version.
+from ._version import __version__
+
+# Store the sire version.
+from sire import __version__ as _sire_version
+from sire import __revisionid__ as _sire_revisionid
+
+# Determine whether we're being run interactively.
+try:
+    _shell = get_ipython().__class__.__name__
+    if _shell == "ZMQInteractiveShell":
+        _is_interactive = True  # Jupyter notebook or qtconsole
+    elif _shell == "TerminalInteractiveShell":
+        _is_interactive = True  # Terminal running IPython
+    else:
+        _is_interactive = False  # Other type (?)
+    del _shell
+except NameError:
+    _is_interactive = False  # Probably standard Python interpreter
+
+if not _is_interactive:
+    # Log the versions of somd2 and sire.
+    _logger.info(f"somd2 version: {__version__}")
+    _logger.info(f"sire version: {_sire_version}+{_sire_revisionid}")
+
+del _is_interactive

--- a/src/somd2/app/run.py
+++ b/src/somd2/app/run.py
@@ -43,13 +43,6 @@ def cli():
 
     from somd2.io import yaml_to_dict
 
-    # Store the somd2 version.
-    from somd2._version import __version__
-
-    # Store the sire version.
-    from sire import __version__ as sire_version
-    from sire import __revisionid__ as sire_revisionid
-
     # Generate the parser.
     parser = Config._create_parser()
 
@@ -85,10 +78,6 @@ def cli():
 
     # Instantiate a Config object to validate the arguments.
     config = Config(**args)
-
-    # Log the versions of somd2 and sire.
-    _logger.info(f"somd2 version: {__version__}")
-    _logger.info(f"sire version: {sire_version}+{sire_revisionid}")
 
     # Instantiate a Runner object to run the simulation.
     runner = Runner(system, config)

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -938,12 +938,16 @@ class Runner:
                 raise
             self._sim._cleanup()
 
+        from somd2 import __version__, _sire_version, _sire_revisionid
+
         # Write final dataframe for the system to the energy trajectory file.
         # Note that sire s3 checkpoint files contain energy trajectory data, so this works even for restarts.
         _ = _dataframe_to_parquet(
             df,
             metadata={
                 "attrs": df.attrs,
+                "somd2 version": __version__,
+                "sire version": f"{_sire_version}+{_sire_revisionid}",
                 "lambda": str(lambda_value),
                 "lambda_array": self._lambda_values,
                 "lambda_grad": lambda_grad,


### PR DESCRIPTION
This PR builds on and closes #39. The `somd2` and `sire` versions are now stored on startup and reported if running in a non-interactive fashion. The versions are also added as additional metadata to the parquet energy trajectory files, so we can more easily cross reference data with versions, i.e. we don't need to keep or grep the log files. I decided not to store the versions in the stream file since we already have validation for configuration compatibility when restarting. (I'm happy to add it if you think it would be beneficial.)

@fjclark: Does this work for you? I wanted to take the logging outside of the `Config` class so that it isn't triggered when unpicking an object of this type, or if the user is creating multiple configs in a script. Basically I want the info to be visible once on startup when it is useful to show, i.e. when in non-interactive mode.