### PR TITLE
Add support for using a custom list of lambda values

### DIFF
--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -654,6 +654,9 @@ class Config:
                     "All entries in 'lambda_values' must be between 0 and 1"
                 )
 
+            # Round to 5dp.
+            lambda_values = [round(x, 5) for x in lambda_values]
+
             self._num_lambda = len(lambda_values)
 
         self._lambda_values = lambda_values
@@ -676,6 +679,9 @@ class Config:
                 raise ValueError(
                     "All entries in 'lambda_energy' must be between 0 and 1"
                 )
+
+            # Round to 5dp.
+            lambda_energy = [round(x, 5) for x in lambda_energy]
 
         self._lambda_energy = lambda_energy
 

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -75,6 +75,7 @@ class Config:
     # A dictionary of nargs for the various options.
     _nargs = {
         "lambda_values": "+",
+        "lambda_energy": "+",
     }
 
     def __init__(
@@ -92,6 +93,7 @@ class Config:
         h_mass_factor=1.5,
         num_lambda=11,
         lambda_values=None,
+        lambda_energy=None,
         lambda_schedule="standard_morph",
         charge_scale_factor=0.2,
         swap_end_states=False,
@@ -162,6 +164,11 @@ class Config:
         lambda_values: [float]
             A list of lambda values. When specified, this takes precedence over
             the 'num_lambda' option.
+
+        lambda_energy: [float]
+            A list of lambda values at which to output energy data. If not set,
+            then this will be set to the same as 'lambda_values', or the values
+            defined by 'num_lambda' if 'lambda_values' is not set.
 
         lambda_schedule: str
             Lambda schedule to use for alchemical free energy simulations.
@@ -292,6 +299,7 @@ class Config:
         self.timestep = timestep
         self.num_lambda = num_lambda
         self.lambda_values = lambda_values
+        self.lambda_energy = lambda_energy
         self.lambda_schedule = lambda_schedule
         self.charge_scale_factor = charge_scale_factor
         self.swap_end_states = swap_end_states
@@ -649,6 +657,27 @@ class Config:
             self._num_lambda = len(lambda_values)
 
         self._lambda_values = lambda_values
+
+    @property
+    def lambda_energy(self):
+        return self._lambda_energy
+
+    @lambda_energy.setter
+    def lambda_energy(self, lambda_energy):
+        if lambda_energy is not None:
+            if not isinstance(lambda_energy, _Iterable):
+                raise ValueError("'lambda_energy' must be an iterable")
+            try:
+                lambda_energy = [float(x) for x in lambda_energy]
+            except:
+                raise ValueError("'lambda_energy' must be an iterable of floats")
+
+            if not all(0 <= x <= 1 for x in lambda_energy):
+                raise ValueError(
+                    "All entries in 'lambda_energy' must be between 0 and 1"
+                )
+
+        self._lambda_energy = lambda_energy
 
     @property
     def lambda_schedule(self):

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -123,15 +123,12 @@ class Dynamics:
         self._filenames = self.create_filenames(
             self._lambda_array,
             self._lambda_val,
-            self._lambda_energy,
             self._config.output_directory,
             self._config.restart,
         )
 
     @staticmethod
-    def create_filenames(
-        lambda_array, lambda_value, lambda_energy, output_directory, restart=False
-    ):
+    def create_filenames(lambda_array, lambda_value, output_directory, restart=False):
         # Create incremental file name for current restart.
         def increment_filename(base_filename, suffix):
             file_number = 0
@@ -149,13 +146,13 @@ class Dynamics:
 
         if lambda_value not in lambda_array:
             raise ValueError("lambda_value not in lambda_array")
+        lam = f"{lambda_value:.5f}"
         filenames = {}
-        index = lambda_array.index(lambda_value)
         filenames["topology"] = "system.prm7"
-        filenames["checkpoint"] = f"checkpoint_{index}.s3"
-        filenames["energy_traj"] = f"energy_traj_{index}.parquet"
-        filenames["trajectory"] = f"traj_{index}.dcd"
-        filenames["trajectory_chunk"] = f"traj_{index}_"
+        filenames["checkpoint"] = f"checkpoint_{lam}.s3"
+        filenames["energy_traj"] = f"energy_traj_{lam}.parquet"
+        filenames["trajectory"] = f"traj_{lam}.dcd"
+        filenames["trajectory_chunk"] = f"traj_{lam}_"
         if restart:
             filenames["config"] = increment_filename("config", "yaml")
         else:

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -43,6 +43,7 @@ class Dynamics:
         system,
         lambda_val,
         lambda_array,
+        lambda_energy,
         config,
         increment=0.001,
         device=None,
@@ -61,8 +62,11 @@ class Dynamics:
             Lambda value for the simulation
 
         lambda_array : list
-            List of lambda values to be used for perturbation, if none won't return
-            reduced perturbed energies
+            List of lambda values to be used for simulation.
+
+        lambda_energy: list
+            List of lambda values to be used for sampling energies. If None, then we
+            won't return reduced perturbed energies.
 
         increment : float
             Increment of lambda value - used for calculating the gradient
@@ -107,18 +111,22 @@ class Dynamics:
 
         self._lambda_val = lambda_val
         self._lambda_array = lambda_array
+        self._lambda_energy = lambda_energy
         self._increment = increment
         self._device = device
         self._has_space = has_space
         self._filenames = self.create_filenames(
             self._lambda_array,
             self._lambda_val,
+            self._lambda_energy,
             self._config.output_directory,
             self._config.restart,
         )
 
     @staticmethod
-    def create_filenames(lambda_array, lambda_value, output_directory, restart=False):
+    def create_filenames(
+        lambda_array, lambda_value, lambda_energy, output_directory, restart=False
+    ):
         # Create incremental file name for current restart.
         def increment_filename(base_filename, suffix):
             file_number = 0
@@ -348,10 +356,10 @@ class Dynamics:
         # Work out the lambda values for finite-difference gradient analysis.
         self._lambda_grad = generate_lam_vals(self._lambda_val, self._increment)
 
-        if self._lambda_array is None:
+        if self._lambda_energy is None:
             lam_arr = self._lambda_grad
         else:
-            lam_arr = self._lambda_array + self._lambda_grad
+            lam_arr = self._lambda_energy + self._lambda_grad
 
         _logger.info(f"Running dynamics at {_lam_sym} = {self._lambda_val}")
 

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -109,6 +109,11 @@ class Dynamics:
         else:
             self._current_block = 0
 
+        lambda_energy = lambda_energy.copy()
+        if not lambda_val in lambda_energy:
+            lambda_energy.append(lambda_val)
+        lambda_energy = sorted(lambda_energy)
+
         self._lambda_val = lambda_val
         self._lambda_array = lambda_array
         self._lambda_energy = lambda_energy
@@ -444,7 +449,7 @@ class Dynamics:
                             metadata={
                                 "attrs": df.attrs,
                                 "lambda": str(self._lambda_val),
-                                "lambda_array": lam_arr,
+                                "lambda_array": self._lambda_energy,
                                 "lambda_grad": self._lambda_grad,
                                 "temperature": str(self._config.temperature.value()),
                             },

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -318,7 +318,6 @@ class Runner:
             files = Dynamics.create_filenames(
                 self._lambda_values,
                 lambda_value,
-                self._lambda_energy,
                 self._config.output_directory,
                 self._config.restart,
             )
@@ -428,10 +427,10 @@ class Runner:
             )
             try:
                 system_temp = _stream.load(
-                    str(self._config.output_directory / "checkpoint_0.s3")
+                    str(self._config.output_directory / "checkpoint_0.00000.s3")
                 )
             except:
-                expdir = self._config.output_directory / "checkpoint_0.s3"
+                expdir = self._config.output_directory / "checkpoint_0.00000.s3"
                 _logger.error(f"Unable to load checkpoint file from {expdir}.")
                 raise
             else:

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -62,11 +62,8 @@ class Runner:
             The perturbable system to be simulated. This can be either a path
             to a stream file, or a Sire system object.
 
-        num_lambda: int
-            The number of lambda windows to be simulated.
-
-        platform: str
-            The platform to be used for simulations.
+        config: :class: `Config <somd2.config.Config>`
+            The configuration options for the simulation.
         """
 
         if not isinstance(system, (str, _System)):
@@ -169,10 +166,13 @@ class Runner:
         self._check_end_state_constraints()
 
         # Set the lambda values.
-        self._lambda_values = [
-            round(i / (self._config.num_lambda - 1), 5)
-            for i in range(0, self._config.num_lambda)
-        ]
+        if self._config.lambda_values:
+            self._lambda_values = self._config.lambda_values
+        else:
+            self._lambda_values = [
+                round(i / (self._config.num_lambda - 1), 5)
+                for i in range(0, self._config.num_lambda)
+            ]
 
         # Work out the current hydrogen mass factor.
         h_mass_factor, has_hydrogen = self._get_h_mass_factor(self._system)

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -178,7 +178,7 @@ class Runner:
         if self._config.lambda_energy is not None:
             self._lambda_energy = self._config.lambda_energy
         else:
-            self._lambda_energy = self._config.lambda_values
+            self._lambda_energy = self._lambda_values
 
         # Work out the current hydrogen mass factor.
         h_mass_factor, has_hydrogen = self._get_h_mass_factor(self._system)

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -174,6 +174,12 @@ class Runner:
                 for i in range(0, self._config.num_lambda)
             ]
 
+        # Set the lambda energy list.
+        if self._config.lambda_energy is not None:
+            self._lambda_energy = self._config.lambda_energy
+        else:
+            self._lambda_energy = self._config.lambda_values
+
         # Work out the current hydrogen mass factor.
         h_mass_factor, has_hydrogen = self._get_h_mass_factor(self._system)
 
@@ -312,6 +318,7 @@ class Runner:
             files = Dynamics.create_filenames(
                 self._lambda_values,
                 lambda_value,
+                self._lambda_energy,
                 self._config.output_directory,
                 self._config.restart,
             )
@@ -679,6 +686,7 @@ class Runner:
                 system,
                 lambda_val=lambda_value,
                 lambda_array=self._lambda_values,
+                lambda_energy=self._lambda_energy,
                 config=self._config,
                 device=device,
                 has_space=self._has_space,
@@ -939,6 +947,12 @@ class Runner:
 
         from somd2 import __version__, _sire_version, _sire_revisionid
 
+        # Add the current lambda value to the list of lambda values and sort.
+        lambda_array = self._lambda_energy.copy()
+        if lambda_value not in lambda_array:
+            lambda_array.append(lambda_value)
+        lambda_array = sorted(lambda_array)
+
         # Write final dataframe for the system to the energy trajectory file.
         # Note that sire s3 checkpoint files contain energy trajectory data, so this works even for restarts.
         _ = _dataframe_to_parquet(
@@ -948,7 +962,7 @@ class Runner:
                 "somd2 version": __version__,
                 "sire version": f"{_sire_version}+{_sire_revisionid}",
                 "lambda": str(lambda_value),
-                "lambda_array": self._lambda_values,
+                "lambda_array": lambda_array,
                 "lambda_grad": lambda_grad,
                 "speed": speed,
                 "temperature": str(self._config.temperature.value()),

--- a/tests/runner/test_lambda_values.py
+++ b/tests/runner/test_lambda_values.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+import tempfile
+import pytest
+
+import sire as sr
+
+from somd2.runner import Runner
+from somd2.config import Config
+from somd2.io import *
+
+
+def test_lambda_values(ethane_methanol):
+    """
+    Validate that a simulation can be run with a custom list of lambda values.
+    """
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mols = ethane_methanol.clone()
+
+        config = {
+            "runtime": "12fs",
+            "restart": False,
+            "output_directory": tmpdir,
+            "energy_frequency": "4fs",
+            "checkpoint_frequency": "4fs",
+            "frame_frequency": "4fs",
+            "platform": "CPU",
+            "max_threads": 1,
+            "lambda_values": [0.0, 0.5, 1.0],
+        }
+
+        # Instantiate a runner using the config defined above.
+        runner = Runner(mols, Config(**config))
+
+        # Run the simulation.
+        runner.run()
+
+        # Load the energy trajectory.
+        energy_traj, meta = parquet_to_dataframe(Path(tmpdir) / "energy_traj_0.parquet")
+
+        # Make sure the lambda_array in the metadata is correct. This is the
+        # lambda_values list in the config.
+        assert meta["lambda_array"] == [0.0, 0.5, 1.0]
+
+        # Make sure the second dimension of the energy trajectory is the correct
+        # size. This is one for the current lambda value, one for its gradient,
+        # and two for the additional values in the lambda_values list.
+        assert energy_traj.shape[1] == 4
+
+
+def test_lambda_energy(ethane_methanol):
+    """
+    Validate that a simulation can sample energies at a different set of
+    lambda values.
+    """
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mols = ethane_methanol.clone()
+
+        config = {
+            "runtime": "12fs",
+            "restart": False,
+            "output_directory": tmpdir,
+            "energy_frequency": "4fs",
+            "checkpoint_frequency": "4fs",
+            "frame_frequency": "4fs",
+            "platform": "CPU",
+            "max_threads": 1,
+            "lambda_values": [0.0, 1.0],
+            "lambda_energy": [0.5],
+        }
+
+        # Instantiate a runner using the config defined above.
+        runner = Runner(mols, Config(**config))
+
+        # Run the simulation.
+        runner.run()
+
+        # Load the energy trajectory.
+        energy_traj, meta = parquet_to_dataframe(Path(tmpdir) / "energy_traj_0.parquet")
+
+        # Make sure the lambda_array in the metadata is correct. This is the
+        # sampled lambda plus the lambda_energy values in the config.
+        assert meta["lambda_array"] == [0.0, 0.5]
+
+        # Make sure the second dimension of the energy trajectory is the correct
+        # size. This is one for the current lambda value, one for its gradient,
+        # and one for the length of lambda_energy.
+        assert energy_traj.shape[1] == 3

--- a/tests/runner/test_lambda_values.py
+++ b/tests/runner/test_lambda_values.py
@@ -37,7 +37,9 @@ def test_lambda_values(ethane_methanol):
         runner.run()
 
         # Load the energy trajectory.
-        energy_traj, meta = parquet_to_dataframe(Path(tmpdir) / "energy_traj_0.parquet")
+        energy_traj, meta = parquet_to_dataframe(
+            Path(tmpdir) / "energy_traj_0.00000.parquet"
+        )
 
         # Make sure the lambda_array in the metadata is correct. This is the
         # lambda_values list in the config.
@@ -78,7 +80,9 @@ def test_lambda_energy(ethane_methanol):
         runner.run()
 
         # Load the energy trajectory.
-        energy_traj, meta = parquet_to_dataframe(Path(tmpdir) / "energy_traj_0.parquet")
+        energy_traj, meta = parquet_to_dataframe(
+            Path(tmpdir) / "energy_traj_0.00000.parquet"
+        )
 
         # Make sure the lambda_array in the metadata is correct. This is the
         # sampled lambda plus the lambda_energy values in the config.

--- a/tests/runner/test_restart.py
+++ b/tests/runner/test_restart.py
@@ -38,19 +38,19 @@ def test_restart(mols, request):
 
         # Load the energy trajectory.
         energy_traj_1, meta_1 = parquet_to_dataframe(
-            Path(tmpdir) / "energy_traj_0.parquet"
+            Path(tmpdir) / "energy_traj_0.00000.parquet"
         )
 
         num_entries = len(energy_traj_1.index)
 
         # Load the trajectory.
         traj_1 = sr.load(
-            [str(Path(tmpdir) / "system.prm7"), str(Path(tmpdir) / "traj_0.dcd")]
+            [str(Path(tmpdir) / "system.prm7"), str(Path(tmpdir) / "traj_0.00000.dcd")]
         )
 
         # Check that both config and lambda have been written
         # as properties to the streamed checkpoint file.
-        checkpoint = sr.stream.load(str(Path(tmpdir) / "checkpoint_0.s3"))
+        checkpoint = sr.stream.load(str(Path(tmpdir) / "checkpoint_0.00000.s3"))
         props = checkpoint.property_keys()
         assert "config" in props
         assert "lambda" in props
@@ -78,7 +78,7 @@ def test_restart(mols, request):
 
         # Load the energy trajectory.
         energy_traj_2, meta_2 = parquet_to_dataframe(
-            Path(tmpdir) / "energy_traj_0.parquet"
+            Path(tmpdir) / "energy_traj_0.00000.parquet"
         )
 
         # Check that first half of energy trajectory is the same
@@ -89,7 +89,7 @@ def test_restart(mols, request):
 
         # Reload the trajectory.
         traj_2 = sr.load(
-            [str(Path(tmpdir) / "system.prm7"), str(Path(tmpdir) / "traj_0.dcd")]
+            [str(Path(tmpdir) / "system.prm7"), str(Path(tmpdir) / "traj_0.00000.dcd")]
         )
 
         # Check that the trajectory is twice as long as the first.
@@ -219,11 +219,11 @@ def test_restart(mols, request):
             file.unlink()
 
         # Load the checkpoint file using sire and change the pressure option
-        sire_checkpoint = sr.stream.load(str(Path(tmpdir) / "checkpoint_0.s3"))
+        sire_checkpoint = sr.stream.load(str(Path(tmpdir) / "checkpoint_0.00000.s3"))
         cfg = sire_checkpoint.property("config")
         cfg["pressure"] = "0.5 atm"
         sire_checkpoint.set_property("config", cfg)
-        sr.stream.save(sire_checkpoint, str(Path(tmpdir) / "checkpoint_0.s3"))
+        sr.stream.save(sire_checkpoint, str(Path(tmpdir) / "checkpoint_0.00000.s3"))
 
         # Load the new checkpoint file and make sure the restart fails
         with pytest.raises(ValueError):


### PR DESCRIPTION
This PR closes #41 by adding support for configuring the runner to use a custom list of lambda values. This can be passed from the command-line as follows:

```
somd2 system.bss --lambda-values 0 0.5 1
```

The options are parsed as multiple strings and conversion to float is attempted and validated when the `Config` is created. We also check that the values are valid, i.e. between 0 and 1 inclusive. This option takes precedence over `num_lambda`, i.e. `num_lambda` will be set to the value of `len(lambda_values)`.

I've also fixed a few docstring issues that I found.