### PR TITLE
Add support for writing energy components to file and preserving the LJ sigma parameter for ghost atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ simulations. Built on top of [Sire](https://github.com/OpenBioSim/sire) and [Ope
 First create a conda environment using the provided environment file:
 
 ```
-mamba env create -f environment.yaml
+conda env create -f environment.yaml
 ```
 
 (We recommend using [Miniforge](https://github.com/conda-forge/miniforge).)
@@ -19,7 +19,7 @@ mamba env create -f environment.yaml
 Now install `somd2` into the environment:
 
 ```
-mamba activate somd2
+conda activate somd2
 pip install --editable .
 ```
 

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -124,6 +124,7 @@ class Config:
         overwrite=False,
         somd1_compatibility=False,
         pert_file=None,
+        save_energy_components=False,
     ):
         """
         Constructor.
@@ -281,6 +282,10 @@ class Config:
         pert_file: str
             The path to a SOMD1 perturbation file to apply to the reference system.
             When set, this will automatically set 'somd1_compatibility' to True.
+
+        save_energy_components: bool
+            Whether to save the energy contribution for each force when checkpointing.
+            This is useful when debugging crashes.
         """
 
         # Setup logger before doing anything else
@@ -327,6 +332,7 @@ class Config:
         self.restart = restart
         self.somd1_compatibility = somd1_compatibility
         self.pert_file = pert_file
+        self.save_energy_components = save_energy_components
 
         self.write_config = write_config
 
@@ -1200,6 +1206,16 @@ class Config:
 
         if pert_file is not None:
             self._somd1_compatibility = True
+
+    @property
+    def save_energy_components(self):
+        return self._save_energy_components
+
+    @save_energy_components.setter
+    def save_energy_components(self, save_energy_components):
+        if not isinstance(save_energy_components, bool):
+            raise ValueError("'save_energy_components' must be of type 'bool'")
+        self._save_energy_components = save_energy_components
 
     @property
     def output_directory(self):

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -151,12 +151,14 @@ class Runner:
 
             # Only check for light atoms by the maxium end state mass if running
             # in SOMD1 compatibility mode. Ghost atoms are considered light when
-            # adding bond constraints.
+            # adding bond constraints. Also fix the LJ sigma for ghost atoms so
+            # it isn't scaled to zero.
             self._config._extra_args["ghosts_are_light"] = True
             self._config._extra_args["check_for_h_by_max_mass"] = True
             self._config._extra_args["check_for_h_by_mass"] = False
             self._config._extra_args["check_for_h_by_element"] = False
             self._config._extra_args["check_for_h_by_ambertype"] = False
+            self._config._extra_args["fix_ghost_sigmas"] = True
 
         # Check for a periodic space.
         self._check_space()

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -114,6 +114,7 @@ class Runner:
 
             _logger.info("Applying SOMD1 perturbation compatibility.")
             self._system = _make_compatible(self._system)
+            self._system = _morph.link_to_reference(self._system)
 
             # Next, swap the water topology so that it is in AMBER format.
 

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -969,5 +969,7 @@ class Runner:
             filename=self._fnames[lambda_value]["energy_traj"],
         )
         del system
-        _logger.success(f"{_lam_sym} = {lambda_value} complete, speed = {speed:.2f} ns day-1")
+        _logger.success(
+            f"{_lam_sym} = {lambda_value} complete, speed = {speed:.2f} ns day-1"
+        )
         return True

--- a/src/somd2/runner/_somd1.py
+++ b/src/somd2/runner/_somd1.py
@@ -70,18 +70,21 @@ def _make_compatible(system):
         # Get an editable version of the molecule.
         edit_mol = mol.edit()
 
-        #####################################
-        # First fix the ghost atom LJ sigmas.
-        #####################################
+        ##################################
+        # First fix zero LJ sigmas values.
+        ##################################
+
+        # Create a null LJParameter.
+        null_lj = _SireMM.LJParameter()
 
         for atom in mol.atoms():
-            # Lambda = 0 state is a dummy, use sigma from the lambda = 1 state.
-            if (
-                atom.property("element0") == element_dummy
-                or atom.property("ambertype0") == ambertype_dummy
-            ):
-                lj0 = atom.property("LJ0")
-                lj1 = atom.property("LJ1")
+            # Get the end state LJ sigma values.
+            lj0 = atom.property("LJ0")
+            lj1 = atom.property("LJ1")
+
+            # Lambda = 0 state has a zero sigma value.
+            if lj0.sigma() == null_lj.sigma():
+                # Use the sigma value from the lambda = 1 state.
                 edit_mol = (
                     edit_mol.atom(atom.index())
                     .set_property(
@@ -89,13 +92,10 @@ def _make_compatible(system):
                     )
                     .molecule()
                 )
-            # Lambda = 1 state is a dummy, use sigma from the lambda = 0 state.
-            elif (
-                atom.property("element1") == element_dummy
-                or atom.property("ambertype1") == ambertype_dummy
-            ):
-                lj0 = atom.property("LJ0")
-                lj1 = atom.property("LJ1")
+
+            # Lambda = 1 state has a zero sigma value.
+            if lj1.sigma() == null_lj.sigma():
+                # Use the sigma value from the lambda = 0 state.
                 edit_mol = (
                     edit_mol.atom(atom.index())
                     .set_property(

--- a/src/somd2/runner/_somd1.py
+++ b/src/somd2/runner/_somd1.py
@@ -61,7 +61,7 @@ def _make_compatible(system):
 
     # Store a dummy element and ambertype.
     element_dummy = _SireMol.Element("Xx")
-    amber_dummy = "du"
+    ambertype_dummy = "du"
 
     for mol in pert_mols:
         # Store the molecule info.
@@ -78,7 +78,7 @@ def _make_compatible(system):
             # Lambda = 0 state is a dummy, use sigma from the lambda = 1 state.
             if (
                 atom.property("element0") == element_dummy
-                or atom.property("ambertype0") == amber_dummy
+                or atom.property("ambertype0") == ambertype_dummy
             ):
                 lj0 = atom.property("LJ0")
                 lj1 = atom.property("LJ1")
@@ -92,7 +92,7 @@ def _make_compatible(system):
             # Lambda = 1 state is a dummy, use sigma from the lambda = 0 state.
             elif (
                 atom.property("element1") == element_dummy
-                or atom.property("ambertype1") == amber_dummy
+                or atom.property("ambertype1") == ambertype_dummy
             ):
                 lj0 = atom.property("LJ0")
                 lj1 = atom.property("LJ1")

--- a/src/somd2/runner/_somd1.py
+++ b/src/somd2/runner/_somd1.py
@@ -681,7 +681,7 @@ def _apply_pert(system, pert_file):
     from sire import morph as _morph
 
     # Get the non-water molecules in the system.
-    non_waters = system["not water"]
+    non_waters = system["not water"].molecules()
 
     # Try to apply the perturbation to each non-water molecule.
     is_pert = False


### PR DESCRIPTION
This PR adds support for writing the energy components (from each force) to a log file for debugging purposes with the `--save-energy-components` command-line option. This also builds on [OpenBioSim/sire#198](https://github.com/OpenBioSim/sire/pull/198) and [OpenBioSim/biosimspace#295](https://github.com/OpenBioSim/biosimspace/pull/295) to prevent perturbation of the LJ sigma parameter for ghost atoms, which causes instability during perturbation.