### PR TITLE
Make sure versions are logged to file

### DIFF
--- a/src/somd2/__init__.py
+++ b/src/somd2/__init__.py
@@ -37,23 +37,3 @@ from ._version import __version__
 # Store the sire version.
 from sire import __version__ as _sire_version
 from sire import __revisionid__ as _sire_revisionid
-
-# Determine whether we're being run interactively.
-try:
-    _shell = get_ipython().__class__.__name__
-    if _shell == "ZMQInteractiveShell":
-        _is_interactive = True  # Jupyter notebook or qtconsole
-    elif _shell == "TerminalInteractiveShell":
-        _is_interactive = True  # Terminal running IPython
-    else:
-        _is_interactive = False  # Other type (?)
-    del _shell
-except NameError:
-    _is_interactive = False  # Probably standard Python interpreter
-
-if not _is_interactive:
-    # Log the versions of somd2 and sire.
-    _logger.info(f"somd2 version: {__version__}")
-    _logger.info(f"sire version: {_sire_version}+{_sire_revisionid}")
-
-del _is_interactive

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -84,6 +84,12 @@ class Runner:
         self._config = config
         self._config._extra_args = {}
 
+        # Log the versions of somd2 and sire.
+        from somd2 import __version__, _sire_version, _sire_revisionid
+
+        _logger.info(f"somd2 version: {__version__}")
+        _logger.info(f"sire version: {_sire_version}+{_sire_revisionid}")
+
         # Check whether we need to apply a perturbation to the reference system.
         if self._config.pert_file is not None:
             _logger.info(


### PR DESCRIPTION
This PR moves the logging of `somd2` and `sire` versions to the `Runner` constructor to ensure that they are logged to file (when a log file is specified). Previously this was done on startup, which occurs before the log file sink is created.

Test failures are due to missing `sire` and `BioSimSpace` builds for the respective platforms. Should hopefully be fixed soon.