### PR TITLE
Only print constraint warning once

### DIFF
--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -306,12 +306,17 @@ class Runner:
             constraints1 = d.get_constraints()
 
             # Check for equivalence.
-            for c0, c1 in zip(constraints0, constraints1):
-                if c0 != c1:
-                    _logger.info(
-                        f"Constraints are at not the same at {_lam_sym} = 0 and {_lam_sym} = 1."
-                    )
-                    break
+            if len(constraints0) != len(constraints1):
+                _logger.info(
+                    f"Constraints are at not the same at {_lam_sym} = 0 and {_lam_sym} = 1."
+                )
+            else:
+                for c0, c1 in zip(constraints0, constraints1):
+                    if c0 != c1:
+                        _logger.info(
+                            f"Constraints are at not the same at {_lam_sym} = 0 and {_lam_sym} = 1."
+                        )
+                        break
 
     def _check_directory(self):
         """

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -311,6 +311,7 @@ class Runner:
                     _logger.info(
                         f"Constraints are at not the same at {_lam_sym} = 0 and {_lam_sym} = 1."
                     )
+                    break
 
     def _check_directory(self):
         """


### PR DESCRIPTION
This PR adds a small fix to ensure that the asymmetric constraint warning is only printed once, i.e. it isn't duplicated if multiple constraints don't match between end states. I've also added an initial check to make sure that the number of constraints is the same, then check each constraint one-by-one.