### PR TITLE
Add alchemical ion support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,7 @@ jobs:
       max-parallel: 9
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
         platform:
           - { name: "windows", os: "windows-latest", shell: "pwsh" }
           - { name: "linux", os: "ubuntu-latest", shell: "bash -l {0}" }

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,12 +55,10 @@ jobs:
           activate-environment: somd2
           environment-file: environment.yaml
           miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: true
           run-post: ${{ matrix.platform.name != 'windows' }}
 #
       - name: Install pytest
-        run: mamba install pytest
+        run: conda install pytest
 #
       - name: Install the package
         run: pip install .

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -215,7 +215,7 @@ class Config:
         charge_difference: int
             The charge difference between the two end states. (Perturbed minus
             reference.) If specified, then a number of alchemical ions will be
-            added to the system to neutralise the charge difference, i.e. make
+            added to the system to keep the charge constant, i.e. make the
             perturbed state charge the same as the reference state.
 
         com_reset_frequency: int

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -104,6 +104,7 @@ class Config:
         perturbable_constraint="h_bonds_not_heavy_perturbed",
         include_constrained_energies=False,
         dynamic_constraints=True,
+        charge_difference=0,
         com_reset_frequency=10,
         minimise=True,
         equilibration_time="0ps",
@@ -211,6 +212,12 @@ class Config:
             to the value of r0 at that lambda value. If this is False, then
             the constraint is set based on the current length.
 
+        charge_difference: int
+            The charge difference between the two end states. (Perturbed minus
+            reference.) If specified, then a number of alchemical ions will be
+            added to the system to neutralise the charge difference, i.e. make
+            perturbed state charge the same as the reference state.
+
         com_reset_frequency: int
             Frequency at which to reset the centre of mass of the system.
 
@@ -315,6 +322,7 @@ class Config:
         self.perturbable_constraint = perturbable_constraint
         self.include_constrained_energies = include_constrained_energies
         self.dynamic_constraints = dynamic_constraints
+        self.charge_difference = charge_difference
         self.com_reset_frequency = com_reset_frequency
         self.minimise = minimise
         self.equilibration_time = equilibration_time
@@ -860,6 +868,17 @@ class Config:
         if not isinstance(dynamic_constraints, bool):
             raise ValueError("'dynamic_constraints' must be of type 'bool'")
         self._dynamic_constraints = dynamic_constraints
+
+    @property
+    def charge_difference(self):
+        return self._charge_difference
+
+    @charge_difference.setter
+    def charge_difference(self, charge_difference):
+        if charge_difference is not None:
+            if not isinstance(charge_difference, int):
+                raise ValueError("'charge_difference' must be an integer")
+        self._charge_difference = charge_difference
 
     @property
     def com_reset_frequency(self):

--- a/src/somd2/runner/_dynamics.py
+++ b/src/somd2/runner/_dynamics.py
@@ -151,7 +151,8 @@ class Dynamics:
             raise ValueError("lambda_value not in lambda_array")
         lam = f"{lambda_value:.5f}"
         filenames = {}
-        filenames["topology"] = "system.prm7"
+        filenames["topology0"] = "system0.prm7"
+        filenames["topology1"] = "system1.prm7"
         filenames["checkpoint"] = f"checkpoint_{lam}.s3"
         filenames["energy_traj"] = f"energy_traj_{lam}.parquet"
         filenames["trajectory"] = f"traj_{lam}.dcd"
@@ -307,8 +308,12 @@ class Dynamics:
 
         # Save the system topology to a PRM7 file that can be used to load the
         # trajectory.
-        topology = str(self._config.output_directory / self._filenames["topology"])
-        sr.save(self._system, topology)
+        topology0 = str(self._config.output_directory / self._filenames["topology0"])
+        topology1 = str(self._config.output_directory / self._filenames["topology1"])
+        mols0 = sr.morph.link_to_reference(self._system)
+        mols1 = sr.morph.link_to_perturbed(self._system)
+        sr.save(mols0, topology0)
+        sr.save(mols1, topology1)
 
         def generate_lam_vals(lambda_base, increment):
             """Generate lambda values for a given lambda_base and increment"""
@@ -560,7 +565,7 @@ class Dynamics:
                     traj_chunks = [f"{traj_filename}.bak"] + traj_chunks
 
             # Load the topology and chunked trajectory files.
-            system = sr.load([topology] + traj_chunks)
+            system = sr.load([topology0] + traj_chunks)
 
             # Save the final trajectory to a single file.
             traj_filename = str(

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -193,7 +193,9 @@ class Runner:
 
         # Create alchemical ions.
         if self._config.charge_difference != 0:
-            self._create_alchemical_ions(self._system, self._config.charge_difference)
+            self._system = self._create_alchemical_ions(
+                self._system, self._config.charge_difference
+            )
 
         # Set the lambda values.
         if self._config.lambda_values:

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -179,7 +179,7 @@ class Runner:
         # Make sure the difference is integer valued to 5 decimal places.
         if not round(charge_diff, 4).is_integer():
             _logger.warning("Charge difference between end states is not an integer.")
-        charge_diff = round(charge_diff, 4)
+        charge_diff = int(round(charge_diff, 4))
 
         # Make sure the charge difference matches the expected value
         # from the config.

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -187,8 +187,8 @@ class Runner:
             _logger.warning(
                 f"The charge difference of {charge_diff} between the end states "
                 f"does not match the expected value of {self._config.charge_difference}. "
-                "Please specify the 'charge_difference' if you wish to maintain "
-                "charge neutrality."
+                "Please specify the 'charge_difference' if you wish to keep the charge "
+                "constant."
             )
 
         # Create alchemical ions.
@@ -366,7 +366,7 @@ class Runner:
     @staticmethod
     def _create_alchemical_ions(system, charge_diff):
         """
-        Internal function to create alchemical ions to maintain charge neutrality.
+        Internal function to create alchemical ions to maintain a constant charge.
 
         Parameters
         ----------
@@ -435,7 +435,7 @@ class Runner:
             # Log that the water was perturbed.
             _logger.info(
                 f"Water at molecule index {index} will be perturbed to "
-                f"{ion_str} to preserve charge neutrality."
+                f"{ion_str} to keep charge constant."
             )
 
         return system

--- a/tests/runner/test_alchemical_ions.py
+++ b/tests/runner/test_alchemical_ions.py
@@ -1,0 +1,31 @@
+import math
+
+from somd2.runner import Runner
+
+
+def test_alchemical_ions(ethane_methanol):
+    """Ensure that alchemical ions are added correctly."""
+
+    # Clone the system.
+    mols = ethane_methanol.clone()
+
+    # Helper function to return the charge difference between the end states.
+    def charge_difference(mols):
+        from sire import morph
+
+        reference = morph.link_to_reference(mols)
+        perturbed = morph.link_to_perturbed(mols)
+
+        return (perturbed.charge() - reference.charge()).value()
+
+    # Add 10 Cl- ions.
+    new_mols = Runner._create_alchemical_ions(mols, 10)
+
+    # Make sure the charge difference is correct.
+    assert math.isclose(charge_difference(new_mols), -10.0, rel_tol=1e-6)
+
+    # Add 10 Na+ ions.
+    new_mols = Runner._create_alchemical_ions(mols, -10)
+
+    # Make sure the charge difference is correct.
+    assert math.isclose(charge_difference(new_mols), 10.0, rel_tol=1e-6)

--- a/tests/runner/test_alchemical_ions.py
+++ b/tests/runner/test_alchemical_ions.py
@@ -9,23 +9,14 @@ def test_alchemical_ions(ethane_methanol):
     # Clone the system.
     mols = ethane_methanol.clone()
 
-    # Helper function to return the charge difference between the end states.
-    def charge_difference(mols):
-        from sire import morph
-
-        reference = morph.link_to_reference(mols)
-        perturbed = morph.link_to_perturbed(mols)
-
-        return (perturbed.charge() - reference.charge()).value()
-
     # Add 10 Cl- ions.
     new_mols = Runner._create_alchemical_ions(mols, 10)
 
     # Make sure the charge difference is correct.
-    assert math.isclose(charge_difference(new_mols), -10.0, rel_tol=1e-6)
+    assert math.isclose(Runner._get_charge_difference(new_mols), -10.0, rel_tol=1e-6)
 
     # Add 10 Na+ ions.
     new_mols = Runner._create_alchemical_ions(mols, -10)
 
     # Make sure the charge difference is correct.
-    assert math.isclose(charge_difference(new_mols), 10.0, rel_tol=1e-6)
+    assert math.isclose(Runner._get_charge_difference(new_mols), 10.0, rel_tol=1e-6)

--- a/tests/runner/test_restart.py
+++ b/tests/runner/test_restart.py
@@ -45,7 +45,7 @@ def test_restart(mols, request):
 
         # Load the trajectory.
         traj_1 = sr.load(
-            [str(Path(tmpdir) / "system.prm7"), str(Path(tmpdir) / "traj_0.00000.dcd")]
+            [str(Path(tmpdir) / "system0.prm7"), str(Path(tmpdir) / "traj_0.00000.dcd")]
         )
 
         # Check that both config and lambda have been written
@@ -89,7 +89,7 @@ def test_restart(mols, request):
 
         # Reload the trajectory.
         traj_2 = sr.load(
-            [str(Path(tmpdir) / "system.prm7"), str(Path(tmpdir) / "traj_0.00000.dcd")]
+            [str(Path(tmpdir) / "system0.prm7"), str(Path(tmpdir) / "traj_0.00000.dcd")]
         )
 
         # Check that the trajectory is twice as long as the first.


### PR DESCRIPTION
This PR adds support for adding alchemical ions to enforce charge neutrality during a perturbation. Currently the number of ions to apply to the perturbed state is configured via the `--charge-difference` command-line option. This specifies the difference in charge between the perturbed and reference states, i.e. charge(perturbed) minus charge(reference). For reference, the indices of the water molecules that are perturbed are written to the log. We also check the difference in end-state charge for _all_ simulations and warn the user when there is a mismatch, i.e. suggesting to use `--charge-difference` if they want to preserve neutrality. In future, all of this could be automated if we want to completely remove the option, e.g. we could have some `--charge-neutral` flag that is `True` by default.

Currently we use the `furthest N from X,Y,Z` syntax to choose water molecules for perturbation. Here `N` is the number of ions that we need and `X,Y,Z` specifies the coordinates for the center of mass of the perturbable molecule. This results in a reproducible search for the same input. If we find that this causes issues, e.g. choosing a problematic water, then we could increase the number of molecules in the search, then pick randomly, e.g. first choosing `10N` closest waters, then randomly choosing `N` from within this.

One point of difference with `somd1` is the definition of the `charge_difference` option. Here it specifies the difference in charge between the perturbed and reference states, whereas for `somd1` the difference appears to be reversed. (Which means the charge difference is the charge you need to _add_ to the perturbed state to make it the same as the reference.) I'm happy to swap to whatever, but this definition seems less confusing to me and more in line with have the _reference_ state actually be a reference.

The PR also contains a commit to save topology files for both end states to the output directory, i.e. `system0.prm7` and `system1.prm7`. This allows a user to visualise or analyse trajectories using either topology as a reference. (This has been very useful for debugging angle distributions around perturbing atoms, for example.)

Happy for this PR to sit here so that @jmichel80 can comment before merging. 