### PR TITLE
Small fix for parquet files when checkpointing is switched off

### DIFF
--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -656,9 +656,16 @@ class Runner(_RunnerBase):
 
             # Get the simulation speed.
             speed = dynamics.time_speed()
-
             # Checkpoint.
-            self._checkpoint(system, index, 0, speed, is_final_block=True)
+            self._checkpoint(
+                system,
+                index,
+                0,
+                speed,
+                is_final_block=True,
+                lambda_grad=lambda_grad,
+                lambda_energy=lambda_energy,
+            )
 
             _logger.success(
                 f"{_lam_sym} = {lambda_value:.5f} complete, speed = {speed:.2f} ns day-1"


### PR DESCRIPTION
Currently, in the base runner, turning off checkpointing causes downstream issues with analysis as `lambda_grad` is not written to the parquet files. This fixes that and also ensures that `lambda_energy` is also passed.