### PR TITLE
Fix issue #90

### DIFF
--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -938,6 +938,9 @@ class Runner(_RunnerBase):
             # Calculate the speed in nanoseconds per day.
             speed = time.to("ns") / days
 
+            # Create the lock.
+            lock = _FileLock(self._lock_file)
+
             # Acquire the file lock to ensure that the checkpoint files are
             # in a consistent state if read by another process.
             with lock.acquire(timeout=self._config.timeout.to("seconds")):


### PR DESCRIPTION
This PR closes #90 by creating the timer start variable outside of any conditional blocks. The PR also ensures that a lock is created prior to writing the final checkpoint when the simulation has finished.