### PR TITLE
Fix issue #99

### DIFF
--- a/src/somd2/runner/_base.py
+++ b/src/somd2/runner/_base.py
@@ -124,7 +124,7 @@ class RunnerBase:
 
         # Flag whether frames are being saved.
         if (
-            self.config.save_trajectories
+            self._config.save_trajectories
             and self._config.frame_frequency > 0
             and self._config.frame_frequency <= self._config.runtime
         ):


### PR DESCRIPTION
This PR closes #99 by...

* Make sure the user wants to save trajectories when setting the `save_frames` flag.
* Making sure that trajectory chunk files exist _before_ attempting to reconstruct and save the trajectory during the final checkpoint.
* Removing an incorrect and redundant configuration option.