### PR TITLE
Allow perturbed system option to be a Sire system and a string

### DIFF
--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -1624,7 +1624,10 @@ class Config:
     @perturbed_system.setter
     def perturbed_system(self, perturbed_system):
         if perturbed_system is not None:
-            if isinstance(perturbed_system, str):
+            if isinstance(perturbed_system, _sr.system.System):
+                self._perturbed_system = perturbed_system
+                self._perturbed_system_file = None
+            elif isinstance(perturbed_system, str):
                 import os
 
                 if not os.path.exists(perturbed_system):
@@ -1640,7 +1643,9 @@ class Config:
                         f"Unable to load 'perturbed_system' stream file: {e}"
                     )
             else:
-                raise TypeError("'perturbed_system' must be of type 'str'")
+                raise TypeError(
+                    "'perturbed_system' must be of type 'sr.system.System' or 'str'"
+                )
         else:
             self._perturbed_system = None
             self._perturbed_system_file = None


### PR DESCRIPTION
This PR allows the perturbed system config option to be set using a Sire system as well as a string, making it easier to set the config option when using the Python API.

@tom-potter-cresset