### PR TITLE
Use length of index list when reporting size of REST2 region

### DIFF
--- a/src/somd2/runner/_base.py
+++ b/src/somd2/runner/_base.py
@@ -446,7 +446,7 @@ class RunnerBase:
 
         # Log the atom indices in the REST2 selection.
         if is_rest2:
-            _logger.info(f"REST2 selection contains {len(atoms)} atoms: {idxs}")
+            _logger.info(f"REST2 selection contains {len(idxs)} atoms: {idxs}")
 
         # Apply hydrogen mass repartitioning.
         if self._config.hmr:


### PR DESCRIPTION
Small fix to use the length of the REST2 index list when reporting its size, which can differ from the size of the atoms list.