### PR TITLE
Fix setting of perturbable system positions for GCMC

### DIFF
--- a/src/somd2/runner/_repex.py
+++ b/src/somd2/runner/_repex.py
@@ -310,6 +310,21 @@ class DynamicsCache:
             ):
                 from openmm.unit import angstrom
 
+                # Get the positions from the context.
+                positions = (
+                    dynamics.context()
+                    .getState(getPositions=True)
+                    .getPositions(asNumpy=True)
+                )
+
+                # The positions array also contains the ghost water atoms that
+                # were added during the GCMC setup. We need to make sure that
+                # we copy these over to the perturbed positions array.
+                diff = len(positions) - len(perturbed_positions)
+                perturbed_positions = _np.concatenate(
+                    [perturbed_positions, positions[-diff:]]
+                )
+
                 dynamics.context().setPeriodicBoxVectors(*perturbed_box * angstrom)
                 dynamics.context().setPositions(perturbed_positions * angstrom)
 

--- a/src/somd2/runner/_repex.py
+++ b/src/somd2/runner/_repex.py
@@ -315,7 +315,7 @@ class DynamicsCache:
                     dynamics.context()
                     .getState(getPositions=True)
                     .getPositions(asNumpy=True)
-                )
+                ) / angstrom
 
                 # The positions array also contains the ghost water atoms that
                 # were added during the GCMC setup. We need to make sure that

--- a/src/somd2/runner/_repex.py
+++ b/src/somd2/runner/_repex.py
@@ -321,9 +321,10 @@ class DynamicsCache:
                 # were added during the GCMC setup. We need to make sure that
                 # we copy these over to the perturbed positions array.
                 diff = len(positions) - len(perturbed_positions)
-                perturbed_positions = _np.concatenate(
-                    [perturbed_positions, positions[-diff:]]
-                )
+                if diff != 0:
+                    perturbed_positions = _np.concatenate(
+                        [perturbed_positions, positions[-diff:]]
+                    )
 
                 dynamics.context().setPeriodicBoxVectors(*perturbed_box * angstrom)
                 dynamics.context().setPositions(perturbed_positions * angstrom)


### PR DESCRIPTION
This PR fixes the setting of positions in the OpenMM context using the perturbable system when performing GCMC. Previously, we had forgotten to account for the extra ghost waters added during the GCMC setup stage. Now we append these extra positions to the array before setting them in the context.