### PR TITLE
Fix repex restart state sychronisation

### DIFF
--- a/src/somd2/runner/_repex.py
+++ b/src/somd2/runner/_repex.py
@@ -812,15 +812,17 @@ class RepexRunner(_RunnerBase):
             for i in range(len(self._lambda_values)):
                 dynamics, gcmc_sampler = self._dynamics_cache.get(i)
 
-                # Reset the OpenMM state.
-                dynamics.context().setState(self._dynamics_cache._openmm_states[i])
+                # Reset the OpenMM state, applying the last replica exchange
+                # mixing so the correct post-mix state is restored.
+                state = self._dynamics_cache._states[i]
+                dynamics.context().setState(self._dynamics_cache._openmm_states[state])
 
                 # Reset the GCMC water state.
                 if gcmc_sampler is not None:
                     gcmc_sampler.push()
                     gcmc_sampler._set_water_state(
                         dynamics.context(),
-                        states=self._dynamics_cache._gcmc_states[i],
+                        states=self._dynamics_cache._gcmc_states[state],
                         force=True,
                     )
                     gcmc_sampler.pop()


### PR DESCRIPTION
This PR fixes a bug where restarting a replica exchange simulation would restore each replica's OpenMM context and GCMC water state from its own pre-mix saved state, discarding the last round of replica exchange mixing. Since mixing occurs at the end of each cycle and the next cycle's dynamics run directly from the post-mix context, the correct state to restore is `_openmm_states[_states[i]`] rather than `_openmm_states[i]`, and similarly for the GCMC water state. This ensures that extended or restarted runs continue from exactly the same state as an uninterrupted simulation would. of repex states on restart. 