### PR TITLE
Feature DMR

### DIFF
--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -1024,14 +1024,16 @@ class Config:
                     self._lambda_schedule = _LambdaSchedule.charge_scaled_morph(0.2)
                     self._lambda_schedule_name = "charge_scaled_morph"
                 elif lambda_schedule == "ring_break_morph":
-                    self._lambda_schedule = _LambdaSchedule.standard_morph()
                     self._lambda_schedule.prepend_stage(
                         "restraints_off", self._lambda_schedule.initial()
                     )
                     self._lambda_schedule.set_equation(
                         stage="restraints_off",
-                        lever="restraint",
+                        lever="morse_soft",
                         equation=1 - self._lambda_schedule.lam(),
+                    )
+                    self._lambda_schedule.set_equation(
+                        stage="restraints_off", lever="morse_hard", equation=0
                     )
                     self._lambda_schedule.set_equation(
                         stage="restraints_off",
@@ -1071,13 +1073,17 @@ class Config:
                         * self._lambda_schedule.initial()
                         + self._lambda_schedule.lam() * self._lambda_schedule.final(),
                     )
-
                     self._lambda_schedule.prepend_stage(
                         "potential_swap", self._lambda_schedule.initial()
                     )
                     self._lambda_schedule.set_equation(
                         stage="potential_swap",
-                        lever="restraint",
+                        lever="morse_hard",
+                        equation=1 - self._lambda_schedule.lam(),
+                    )
+                    self._lambda_schedule.set_equation(
+                        stage="potential_swap",
+                        lever="morse_soft",
                         equation=0 + self._lambda_schedule.lam(),
                     )
                     self._lambda_schedule.set_equation(
@@ -1114,11 +1120,12 @@ class Config:
                         lever="torsion_phase",
                         equation=self._lambda_schedule.initial(),
                     )
-
                     self._lambda_schedule.set_equation(
-                        stage="morph", lever="restraint", equation=0
+                        stage="morph", lever="morse_hard", equation=0
                     )
-
+                    self._lambda_schedule.set_equation(
+                        stage="morph", lever="morse_soft", equation=0
+                    )
                     self._lambda_schedule.set_equation(
                         stage="morph",
                         lever="bond_k",
@@ -1149,13 +1156,13 @@ class Config:
                         lever="torsion_phase",
                         equation=self._lambda_schedule.final(),
                     )
-                    self._lambda_schedule_name = "ring_break_morph"
                 elif lambda_schedule == "reverse_ring_break_morph":
-                    self._lambda_schedule = _LambdaSchedule.standard_morph()
                     self._lambda_schedule.set_equation(
-                        stage="morph", lever="restraint", equation=0
+                        stage="morph", lever="morse_hard", equation=0
                     )
-
+                    self._lambda_schedule.set_equation(
+                        stage="morph", lever="morse_soft", equation=0
+                    )
                     self._lambda_schedule.set_equation(
                         stage="morph",
                         lever="bond_k",
@@ -1192,8 +1199,11 @@ class Config:
                     )
                     self._lambda_schedule.set_equation(
                         stage="bonded_perturb",
-                        lever="restraint",
+                        lever="morse_soft",
                         equation=0 + self._lambda_schedule.lam(),
+                    )
+                    self._lambda_schedule.set_equation(
+                        stage="bonded_perturb", lever="morse_hard", equation=0
                     )
                     self._lambda_schedule.set_equation(
                         stage="bonded_perturb",
@@ -1239,7 +1249,12 @@ class Config:
                     )
                     self._lambda_schedule.set_equation(
                         stage="potential_swap",
-                        lever="restraint",
+                        lever="morse_hard",
+                        equation=0 + self._lambda_schedule.lam(),
+                    )
+                    self._lambda_schedule.set_equation(
+                        stage="potential_swap",
+                        lever="morse_soft",
                         equation=1 - self._lambda_schedule.lam(),
                     )
                     self._lambda_schedule.set_equation(
@@ -1276,7 +1291,6 @@ class Config:
                         lever="torsion_phase",
                         equation=self._lambda_schedule.final(),
                     )
-                    self._lambda_schedule_name = "reverse_ring_break_morph"
                 else:
                     try:
                         self._lambda_schedule = self._from_hex(lambda_schedule)

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -1156,6 +1156,7 @@ class Config:
                         lever="torsion_phase",
                         equation=self._lambda_schedule.final(),
                     )
+                    self._lambda_schedule_name = "ring_break_morph"
                 elif lambda_schedule == "reverse_ring_break_morph":
                     self._lambda_schedule = _LambdaSchedule.standard_morph()
                     self._lambda_schedule.set_equation(
@@ -1292,7 +1293,7 @@ class Config:
                         lever="torsion_phase",
                         equation=self._lambda_schedule.final(),
                     )
-
+                    self._lambda_schedule_name = "reverse_ring_break_morph"
                 else:
                     try:
                         self._lambda_schedule = self._from_hex(lambda_schedule)

--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -1024,6 +1024,7 @@ class Config:
                     self._lambda_schedule = _LambdaSchedule.charge_scaled_morph(0.2)
                     self._lambda_schedule_name = "charge_scaled_morph"
                 elif lambda_schedule == "ring_break_morph":
+                    self._lambda_schedule = _LambdaSchedule.standard_morph()
                     self._lambda_schedule.prepend_stage(
                         "restraints_off", self._lambda_schedule.initial()
                     )
@@ -1031,9 +1032,6 @@ class Config:
                         stage="restraints_off",
                         lever="morse_soft",
                         equation=1 - self._lambda_schedule.lam(),
-                    )
-                    self._lambda_schedule.set_equation(
-                        stage="restraints_off", lever="morse_hard", equation=0
                     )
                     self._lambda_schedule.set_equation(
                         stage="restraints_off",
@@ -1073,6 +1071,7 @@ class Config:
                         * self._lambda_schedule.initial()
                         + self._lambda_schedule.lam() * self._lambda_schedule.final(),
                     )
+
                     self._lambda_schedule.prepend_stage(
                         "potential_swap", self._lambda_schedule.initial()
                     )
@@ -1120,6 +1119,7 @@ class Config:
                         lever="torsion_phase",
                         equation=self._lambda_schedule.initial(),
                     )
+
                     self._lambda_schedule.set_equation(
                         stage="morph", lever="morse_hard", equation=0
                     )
@@ -1157,6 +1157,7 @@ class Config:
                         equation=self._lambda_schedule.final(),
                     )
                 elif lambda_schedule == "reverse_ring_break_morph":
+                    self._lambda_schedule = _LambdaSchedule.standard_morph()
                     self._lambda_schedule.set_equation(
                         stage="morph", lever="morse_hard", equation=0
                     )
@@ -1291,6 +1292,7 @@ class Config:
                         lever="torsion_phase",
                         equation=self._lambda_schedule.final(),
                     )
+
                 else:
                     try:
                         self._lambda_schedule = self._from_hex(lambda_schedule)


### PR DESCRIPTION
This PR updates the existing `ring_break_morph` and `reverse_ring_break_morph` schedules to use Direct Morse Replacement (DMR) approach rather than the original indirect approach. Key modifications are the introduction of a "hard" and "soft" Morse bond potential restraints which are used to carry out the bond-annihilation, everything else remains unchanged.

`ring_break_morph` schedule:
<img width="817" height="851" alt="image" src="https://github.com/user-attachments/assets/408dc021-07d8-48ca-a986-fbea56f06371" />

`reverse_ring_break_morph` schedule:
<img width="817" height="851" alt="image" src="https://github.com/user-attachments/assets/55c2fd34-b5c2-4c4b-ab4a-17a68364a8e1" />

I have done limited single replicate testing that shows the reverse schedule gives the exact opposite answer for the CHK1 C20 --> C17 vacuum leg (when running C17 --> C20). 