### PR TITLE
Fix missing restraints lever equation from ring_break_morph schedule

### DIFF
--- a/src/somd2/config/_config.py
+++ b/src/somd2/config/_config.py
@@ -1034,6 +1034,9 @@ class Config:
                         equation=1 - self._lambda_schedule.lam(),
                     )
                     self._lambda_schedule.set_equation(
+                        stage="restraints_off", lever="morse_hard", equation=0
+                    )
+                    self._lambda_schedule.set_equation(
                         stage="restraints_off",
                         lever="bond_k",
                         equation=self._lambda_schedule.final(),


### PR DESCRIPTION
This PR fixes the `ring_break_morph` schedule to force `morse_hard` lever to stay at `0` during the middle part of the lambda schedule.