### PR TITLE
Ensure GCMC water count is up-to-date before resetting sampler

### DIFF
--- a/src/somd2/runner/_repex.py
+++ b/src/somd2/runner/_repex.py
@@ -1992,6 +1992,13 @@ class RepexRunner(_RunnerBase):
         dynamics: sire.mol.Dynamics
             The dynamics object associated with the GCMC sampler.
         """
+        # Ensure the water count is up to date before resetting. If the last
+        # move was a bulk sampling move, _is_bulk is True and num_waters()
+        # needs the stored context to recompute _N. Calling it here, while
+        # the context is still available, clears _is_bulk so that reset()
+        # can safely null the context.
+        gcmc_sampler.num_waters()
+
         # Reset the GCMC sampler. This resets the sampling statistics and
         # clears the associated OpenMM forces.
         gcmc_sampler.reset()

--- a/src/somd2/runner/_runner.py
+++ b/src/somd2/runner/_runner.py
@@ -639,6 +639,12 @@ class Runner(_RunnerBase):
         # Reset the GCMC sampler. This resets the sampling statistics and clears
         # the associated OpenMM forces.
         if gcmc_sampler is not None:
+            # Ensure the water count is up to date before resetting. If the
+            # last move was a bulk sampling move, _is_bulk is True and
+            # num_waters() needs the stored context to recompute _N. Calling
+            # it here, while the context is still available, clears _is_bulk
+            # so that reset() can safely null the context.
+            gcmc_sampler.num_waters()
             gcmc_sampler.reset()
 
             # Bind the GCMC sampler to the dynamics object.


### PR DESCRIPTION
This PR makes sure that the GCMC region water count is up-to-date before resetting the `GCMCSampler` at the end of an equilibration block. Otherwise, the sampler requires access to the OpenMM context in order to recompute the number following a bulk move, which would have been cleared by the reset.