### PR TITLE
Add support for GCMC in osmotic ensemble

### DIFF
--- a/src/somd2/runner/_base.py
+++ b/src/somd2/runner/_base.py
@@ -647,11 +647,6 @@ class RunnerBase:
                 _logger.error(msg)
                 raise ValueError(msg)
 
-            if self._config.pressure != None:
-                msg = "GCMC simulations must be run in the NVT ensemble."
-                _logger.error(msg)
-                raise ValueError(msg)
-
             if isinstance(self._system, list):
                 mols = self._system[0]
             else:
@@ -894,6 +889,7 @@ class RunnerBase:
                 "lambda_schedule": self._config.lambda_schedule,
                 "no_logger": True,
                 "num_ghost_waters": self._config.gcmc_num_waters,
+                "pressure": self._config.pressure,
                 "overwrite": self._config.overwrite,
                 "radius": str(self._config.gcmc_radius),
                 "reference": self._config.gcmc_selection,


### PR DESCRIPTION
This PR adds support for GCMC in the osmotic ensemble, i.e. volume can fluctuate too. This approach allows for a simplified setup, since the box size doesn't need to match when using multi-conformational seeding. We'd need to investigate how the ensemble affects sampling and accuracy, e.g. there would be correlated fluctuations between V and N, which could increase variance.