### PR TITLE
Fix issue #188

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog
 * Parallelise replica mixing [#181](https://github.com/OpenBioSim/somd2/pull/181).
 * Fixed the replica exchange GPU memory check querying the wrong device when `CUDA_VISIBLE_DEVICES` does not start at zero, since OpenMM numbers devices relative to the visible set whereas `pynvml` enumerates all of them [#183](https://github.com/OpenBioSim/somd2/issues/183).
 * Store GCMC sampling statistics per lambda value, converting those from earlier checkpoints on restart [#184](https://github.com/OpenBioSim/somd2/pull/184).
+* Link restart systems to the reference end state rather than the perturbed one, since that is the coordinate set that dynamics maintains. Perturbable molecules were otherwise resumed from the coordinates they were built with [#189](https://github.com/OpenBioSim/somd2/pull/189).
 
 [2026.1.0](https://github.com/openbiosim/somd2/compare/2025.1.0...2026.1.0) - Jun 2026
 --------------------------------------------------------------------------------------

--- a/src/somd2/runner/_base.py
+++ b/src/somd2/runner/_base.py
@@ -1723,7 +1723,7 @@ class RunnerBase:
                         raise ValueError(msg)
 
                 # Store the system to the list.
-                systems[i] = _sr.morph.link_to_perturbed(system)
+                systems[i] = _sr.morph.link_to_reference(system)
 
         # If this is a GCMC simulation, then remove all ghost waters from each of the systems.
         if self._config.gcmc:


### PR DESCRIPTION
This PR closes #188 by using `link_to_reference` after loading the restart systems from checkpoint. A regression in ef36f2a switched to `link_to_perturbed`, which meant that the perturbable molecules coordinates were reset to the initial state. Minimisation solved this in practice, but not if `coordinates1` happened to be in a different reference frame.